### PR TITLE
EE-6488: OAuth2 provider config validates `clientSecurityProvider` as

### DIFF
--- a/mule-migration-tool-library/src/main/resources/target-versions.properties
+++ b/mule-migration-tool-library/src/main/resources/target-versions.properties
@@ -17,7 +17,7 @@ mule-spring-module=${mule.spring.module.version}
 mule-json-module=2.0.0
 mule-java-module=1.2.0
 mule-cryptography-module=1.0.0
-mule-oauth2-provider-module=1.0.0
+mule-oauth2-provider-module=1.0.1
 mule-compression-module=2.0.2
 
 munit-maven-plugin=${munit.version}

--- a/mule-migration-tool-tests/src/test/java/com/mulesoft/tools/migration/integration/OAuth2ProviderMigrationTestCase.java
+++ b/mule-migration-tool-tests/src/test/java/com/mulesoft/tools/migration/integration/OAuth2ProviderMigrationTestCase.java
@@ -8,7 +8,6 @@ package com.mulesoft.tools.migration.integration;
 
 import org.mule.tck.junit4.rule.DynamicPort;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,7 +15,6 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
-@Ignore("EE-6488")
 public class OAuth2ProviderMigrationTestCase extends EndToEndTestCase {
 
   @Rule


### PR DESCRIPTION
mandatory