### PR TITLE
E2E tests should run only on our pipeline

### DIFF
--- a/migration-contribution-archetype/pom.xml
+++ b/migration-contribution-archetype/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.mulesoft.tools</groupId>
         <artifactId>mule-migration-tool</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>migration-contribution-archetype</artifactId>
     <name>Migration Contribution Archetype</name>

--- a/mule-migration-tool-api/pom.xml
+++ b/mule-migration-tool-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.mulesoft.tools</groupId>
         <artifactId>mule-migration-tool</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>mule-migration-tool-api</artifactId>
     <name>Mule Migration Assistant API</name>

--- a/mule-migration-tool-contribution/pom.xml
+++ b/mule-migration-tool-contribution/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.mulesoft.tools</groupId>
         <artifactId>mule-migration-tool</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>mule-migration-tool-contribution</artifactId>
     <name>Mule Migration Assistant Contribution</name>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.mulesoft.tools</groupId>
             <artifactId>mule-migration-tool-gateway-plugin</artifactId>
-            <version>1.0.0-RC</version>
+            <version>1.0.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/mule-migration-tool-engine/pom.xml
+++ b/mule-migration-tool-engine/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.mulesoft.tools</groupId>
         <artifactId>mule-migration-tool</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>mule-migration-tool-engine</artifactId>
     <name>Mule Migration Assistant Engine</name>

--- a/mule-migration-tool-expression/pom.xml
+++ b/mule-migration-tool-expression/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.mulesoft.tools</groupId>
         <artifactId>mule-migration-tool</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>mule-migration-tool-expression</artifactId>
 

--- a/mule-migration-tool-library/pom.xml
+++ b/mule-migration-tool-library/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.mulesoft.tools</groupId>
         <artifactId>mule-migration-tool</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>mule-migration-tool-library</artifactId>
     <name>Mule Migration Assistant Library</name>

--- a/mule-migration-tool-tck/pom.xml
+++ b/mule-migration-tool-tck/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.mulesoft.tools</groupId>
         <artifactId>mule-migration-tool</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>mule-migration-tool-tck</artifactId>
     <name>Mule Migration Assistant Test utilities</name>

--- a/mule-migration-tool-tests/pom.xml
+++ b/mule-migration-tool-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.mulesoft.tools</groupId>
         <artifactId>mule-migration-tool</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>mule-migration-tool-tests</artifactId>
     <name>Mule Migration Assistant end-to-end tests</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.mulesoft.tools</groupId>
     <artifactId>mule-migration-tool</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Mule Migration Tool</name>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
         <module>mule-migration-tool-engine</module>
         <module>mule-migration-tool-library</module>
         <module>runner</module>
-        <module>mule-migration-tool-tests</module>
         <module>mule-migration-tool-expression</module>
         <module>migration-contribution-archetype</module>
         <module>mule-migration-tool-contribution</module>
@@ -26,6 +25,29 @@
     </modules>
 
     <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>mule-migration-tool-api</module>
+                <module>target-modules</module>
+                <module>mule-migration-tool-tck</module>
+                <module>mule-migration-tool-engine</module>
+                <module>mule-migration-tool-library</module>
+                <module>runner</module>
+                <module>mule-migration-tool-expression</module>
+                <module>migration-contribution-archetype</module>
+                <module>mule-migration-tool-contribution</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>fullIntegration</id>
+            <modules>
+                <module>mule-migration-tool-tests</module>
+            </modules>
+        </profile>
         <profile>
             <id>compatibility</id>
             <modules>
@@ -186,7 +208,7 @@
                         <execution>
                             <phase>verify</phase>
                             <goals>
-                                <goal>check</goal>                                
+                                <goal>check</goal>
                             </goals>
                         </execution>
                     </executions>
@@ -272,7 +294,7 @@
                             <goals>
                                 <goal>prepare-agent</goal>
                             </goals>
-                        </execution>                        
+                        </execution>
                     </executions>
                     <configuration>
                         <haltOnFailure>true</haltOnFailure>
@@ -568,7 +590,7 @@
         <repository>
             <id>mule-releases</id>
             <name>MuleSoft Releases Repository</name>
-            <url>https://repository-master.mulesoft.org/releases/</url>
+            <url>https://repository.mulesoft.org/releases/</url>
         </repository>
         <snapshotRepository>
             <id>mule-snapshots</id>

--- a/runner/pom.xml
+++ b/runner/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.mulesoft.tools</groupId>
         <artifactId>mule-migration-tool</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>mule-migration-assistant-runner</artifactId>
     <name>Mule Migration Assistant Runner</name>
@@ -116,6 +116,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <algorithms>
+                        <algorithm>SHA-256</algorithm>
+                    </algorithms>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/target-modules/pom.xml
+++ b/target-modules/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.mulesoft.tools</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <artifactId>mule-migration-tool-target-modules</artifactId>
     <name>Mule Migration Assistant Library - Target Modules dependencies</name>
     <packaging>jar</packaging>


### PR DESCRIPTION
Due that our E2E tests require EE libraries, we must move them to a specific profile and only execute them on our Jenkins pipelines.

Fixes #399 