### PR TITLE
Salesforce/set payload

### DIFF
--- a/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/steps/salesforce/CreateOperation.java
+++ b/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/steps/salesforce/CreateOperation.java
@@ -61,6 +61,7 @@ public class CreateOperation extends AbstractSalesforceOperationMigrationStep im
             + transformBody + SalesforceUtils.CLOSE_TRANSFORM_BODY_TYPE_JSON);
       }
     });
+    SalesforceUtils.setPayloadToPayloadItems(mule4Operation);
 
     XmlDslUtils.addElementAfter(mule4Operation, mule3Operation);
     mule3Operation.getParentElement().removeContent(mule3Operation);

--- a/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/steps/salesforce/UpdateOperation.java
+++ b/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/steps/salesforce/UpdateOperation.java
@@ -58,6 +58,7 @@ public class UpdateOperation extends AbstractSalesforceOperationMigrationStep im
             + transformBody + SalesforceUtils.CLOSE_TRANSFORM_BODY_TYPE_JSON);
       }
     });
+    SalesforceUtils.setPayloadToPayloadItems(mule4Operation);
 
     XmlDslUtils.addElementAfter(mule4Operation, mule3Operation);
     mule3Operation.getParentElement().removeContent(mule3Operation);

--- a/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/steps/salesforce/UpsertOperation.java
+++ b/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/steps/salesforce/UpsertOperation.java
@@ -62,6 +62,7 @@ public class UpsertOperation extends AbstractSalesforceOperationMigrationStep im
             + transformBody + SalesforceUtils.CLOSE_TRANSFORM_BODY_TYPE_JSON);
       }
     });
+    SalesforceUtils.setPayloadToPayloadItems(mule4Operation);
 
     XmlDslUtils.addElementAfter(mule4Operation, mule3Operation);
     mule3Operation.getParentElement().removeContent(mule3Operation);

--- a/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/tools/SalesforceUtils.java
+++ b/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/tools/SalesforceUtils.java
@@ -73,4 +73,9 @@ public class SalesforceUtils {
     }
   }
 
+  public static void setPayloadToPayloadItems(Element mule4Operation) {
+    mule4Operation.setAttribute("target", "payload");
+    mule4Operation.setAttribute("targetValue", "#[payload.items]");
+  }
+
 }

--- a/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-create.xml
+++ b/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-create.xml
@@ -2,7 +2,7 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:salesforce="http://www.mulesoft.org/schema/mule/salesforce" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
     <flow name="salesforce-create-flow">
-        <salesforce:create doc:name="Salesforce" config-ref="Salesforce__Basic_Authentication" type="Account" doc:description="Notes" headers="#[vars.headers]">
+        <salesforce:create doc:name="Salesforce" config-ref="Salesforce__Basic_Authentication" type="Account" doc:description="Notes" headers="#[vars.headers]" target="payload" targetValue="#[payload.items]">
             <salesforce:records><![CDATA[#[payload]]]></salesforce:records>
         </salesforce:create>
 

--- a/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-createWithAccessTokenId.xml
+++ b/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-createWithAccessTokenId.xml
@@ -2,7 +2,7 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:salesforce="http://www.mulesoft.org/schema/mule/salesforce" xmlns:sfdc="http://www.mulesoft.org/schema/mule/sfdc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/sfdc http://www.mulesoft.org/schema/mule/sfdc/current/mule-sfdc.xsd http://www.mulesoft.org/schema/mule/salesforce http://www.mulesoft.org/schema/mule/salesforce http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
     <flow name="salesforce-createWithAccessTokenId-flow">
-        <salesforce:create doc:name="Salesforce" config-ref="Salesforce_Config" type="Account">
+        <salesforce:create doc:name="Salesforce" config-ref="Salesforce_Config" type="Account" target="payload" targetValue="#[payload.items]">
             <!--Migration INFO: The access token id parameter was removed in salesforce 10.x-->
             <!--<sfdc:create xmlns:sfdc="http://www.mulesoft.org/schema/mule/sfdc" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" config-ref="Salesforce_Config" type="Account" doc:name="Salesforce" accessTokenId="access-token-id">
             <sfdc:objects ref="#[payload]" />

--- a/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-createWithCreateObjectsManually.xml
+++ b/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-createWithCreateObjectsManually.xml
@@ -16,7 +16,7 @@
             </ee:message>
         </ee:transform>
 
-        <salesforce:create doc:name="Salesforce" config-ref="Salesforce__Basic_Authentication" type="Account" />
+        <salesforce:create doc:name="Salesforce" config-ref="Salesforce__Basic_Authentication" type="Account" target="payload" targetValue="#[payload.items]" />
 
     </flow>
 

--- a/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-createWithEditInlineHeaders.xml
+++ b/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-createWithEditInlineHeaders.xml
@@ -2,7 +2,7 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:salesforce="http://www.mulesoft.org/schema/mule/salesforce" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
     <flow name="salesforce-createWithEditInlineHeaders-flow">
-        <salesforce:create doc:name="Salesforce" config-ref="Salesforce__Basic_Authentication" type="Account">
+        <salesforce:create doc:name="Salesforce" config-ref="Salesforce__Basic_Authentication" type="Account" target="payload" targetValue="#[payload.items]">
             <salesforce:headers>
                 <salesforce:header key="secondHeader" value="secondValue" />
                 <salesforce:header key="firstHeader" value="firstValue" />

--- a/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-createWithoutConfig.xml
+++ b/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-createWithoutConfig.xml
@@ -2,7 +2,7 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:salesforce="http://www.mulesoft.org/schema/mule/salesforce" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
     <flow name="salesforce-createWithoutConfig-flow">
-        <salesforce:create doc:name="Salesforce" type="Account" headers="#[vars.headers]">
+        <salesforce:create doc:name="Salesforce" type="Account" headers="#[vars.headers]" target="payload" targetValue="#[payload.items]">
             <!--Migration ERROR: Fail during migrating create operation-->
             <!--    For more information refer to:-->
             <!--        * https://docs.mulesoft.com/salesforce-connector/10.2/salesforce-connector-reference#create-->

--- a/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-createWithoutHeaders.xml
+++ b/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-createWithoutHeaders.xml
@@ -2,7 +2,7 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:salesforce="http://www.mulesoft.org/schema/mule/salesforce" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
     <flow name="salesforce-createWithoutHeaders-flow">
-        <salesforce:create doc:name="Salesforce" config-ref="Salesforce_Config" type="Account">
+        <salesforce:create doc:name="Salesforce" config-ref="Salesforce_Config" type="Account" target="payload" targetValue="#[payload.items]">
             <salesforce:records><![CDATA[#[payload]]]></salesforce:records>
         </salesforce:create>
 

--- a/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-createWithoutType.xml
+++ b/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-createWithoutType.xml
@@ -2,7 +2,7 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:salesforce="http://www.mulesoft.org/schema/mule/salesforce" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
     <flow name="salesforce-createWithoutType-flow">
-        <salesforce:create doc:name="Salesforce" config-ref="Salesforce_Config" headers="vars.headers">
+        <salesforce:create doc:name="Salesforce" config-ref="Salesforce_Config" headers="vars.headers" target="payload" targetValue="#[payload.items]">
             <!--Migration ERROR: Fail during migrating create operation-->
             <!--    For more information refer to:-->
             <!--        * https://docs.mulesoft.com/salesforce-connector/10.2/salesforce-connector-reference#create-->

--- a/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-update.xml
+++ b/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-update.xml
@@ -2,7 +2,7 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:salesforce="http://www.mulesoft.org/schema/mule/salesforce" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/salesforce http://www.mulesoft.org/schema/mule/salesforce http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
     <flow name="salesforce-update-flow">
-        <salesforce:update config-ref="Salesforce_Config" type="Account" doc:name="Salesforce" headers="#[vars.headers]">
+        <salesforce:update config-ref="Salesforce_Config" type="Account" doc:name="Salesforce" headers="#[vars.headers]" target="payload" targetValue="#[payload.items]">
             <salesforce:records><![CDATA[#[payload]]]></salesforce:records>
         </salesforce:update>
     </flow>

--- a/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-updateManuallyObjectsAndHeaders.xml
+++ b/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-updateManuallyObjectsAndHeaders.xml
@@ -16,7 +16,7 @@
             </ee:message>
         </ee:transform>
 
-        <salesforce:update doc:name="Salesforce" config-ref="Salesforce_Config" type="Account">
+        <salesforce:update doc:name="Salesforce" config-ref="Salesforce_Config" type="Account" target="payload" targetValue="#[payload.items]">
             <salesforce:headers>
                 <salesforce:header key="secondHeader" value="secondValue" />
                 <salesforce:header key="firstHeader" value="firstValue" />

--- a/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-updateWithAccessTokenId.xml
+++ b/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-updateWithAccessTokenId.xml
@@ -2,7 +2,7 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:salesforce="http://www.mulesoft.org/schema/mule/salesforce" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/salesforce http://www.mulesoft.org/schema/mule/salesforce http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
     <flow name="salesforce-updateWithAccessTokenId-flow">
-        <salesforce:update doc:name="Salesforce" config-ref="Salesforce__Config" type="Account">
+        <salesforce:update doc:name="Salesforce" config-ref="Salesforce__Config" type="Account" target="payload" targetValue="#[payload.items]">
             <!--Migration INFO: The access token id parameter was removed in salesforce 10.x-->
             <salesforce:records><![CDATA[#[payload]]]></salesforce:records>
         </salesforce:update>

--- a/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-upsert.xml
+++ b/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-upsert.xml
@@ -5,7 +5,7 @@
 
     <flow name="salesforce-upsert-flow">
         <salesforce:upsert doc:name="Salesforce" config-ref="Salesforce__Basic_Authentication" objectType="Account"
-                           externalIdFieldName="ExternalID__c" headers="#[vars.headers]" doc:description="Notes">
+                           externalIdFieldName="ExternalID__c" headers="#[vars.headers]" target="payload" targetValue="#[payload.items]" doc:description="Notes">
             <salesforce:records ><![CDATA[#[payload]]]></salesforce:records>
         </salesforce:upsert>
     </flow>

--- a/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-upsertWithAccessTokenId.xml
+++ b/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-upsertWithAccessTokenId.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:salesforce="http://www.mulesoft.org/schema/mule/salesforce" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
     <flow name="salesforce-upsertWithAccesTokenId-flow">
-        <salesforce:upsert doc:name="Salesforce" config-ref="Salesforce_Config" objectType="Account" externalIdFieldName="ExternalID__c" >
+        <salesforce:upsert doc:name="Salesforce" config-ref="Salesforce_Config" objectType="Account" externalIdFieldName="ExternalID__c"  target="payload" targetValue="#[payload.items]">
             <!--Migration ERROR: The access token id parameter was removed in salesforce 10.x-->
             <salesforce:records><![CDATA[#[payload]]]></salesforce:records>
         </salesforce:upsert>

--- a/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-upsertWithCreateObjectsManually.xml
+++ b/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-upsertWithCreateObjectsManually.xml
@@ -16,7 +16,7 @@
             </ee:message>
         </ee:transform>
 
-        <salesforce:upsert doc:name="Salesforce" config-ref="Salesforce__Basic_Authentication" objectType="Account" externalIdFieldName="ExternalID__c"/>
+        <salesforce:upsert doc:name="Salesforce" config-ref="Salesforce__Basic_Authentication" objectType="Account" externalIdFieldName="ExternalID__c" target="payload" targetValue="#[payload.items]"/>
 
     </flow>
 

--- a/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-upsertWithEditInlineHeaders.xml
+++ b/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-upsertWithEditInlineHeaders.xml
@@ -2,7 +2,7 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:salesforce="http://www.mulesoft.org/schema/mule/salesforce" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
     <flow name="salesforce-upsertWithEditInlineHeaders-flow">
-        <salesforce:upsert doc:name="Salesforce" config-ref="Salesforce__Basic_Authentication" objectType="Account" externalIdFieldName="ExternalID__c">
+        <salesforce:upsert doc:name="Salesforce" config-ref="Salesforce__Basic_Authentication" objectType="Account" externalIdFieldName="ExternalID__c" target="payload" targetValue="#[payload.items]">
             <salesforce:headers>
                 <salesforce:header key="secondHeader" value="secondValue" />
                 <salesforce:header key="firstHeader" value="firstValue" />

--- a/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-upsertWithoutExternalIdFieldName.xml
+++ b/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-upsertWithoutExternalIdFieldName.xml
@@ -4,7 +4,7 @@
       xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
     <flow name="salesforce-upsertWithoutExternalIdFieldName-flow">
-        <salesforce:upsert doc:name="Salesforce" config-ref="Salesforce__Basic_Authentication" objectType="Account" headers="#[vars.headers]">
+        <salesforce:upsert doc:name="Salesforce" config-ref="Salesforce__Basic_Authentication" objectType="Account" headers="#[vars.headers]" target="payload" targetValue="#[payload.items]">
             <salesforce:records ><![CDATA[#[payload]]]></salesforce:records>
         </salesforce:upsert>
     </flow>

--- a/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-upsertWithoutHeaders.xml
+++ b/mule-migration-tool-library/src/test/resources/mule/apps/salesforce/salesforce-upsertWithoutHeaders.xml
@@ -2,7 +2,7 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:salesforce="http://www.mulesoft.org/schema/mule/salesforce" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
     <flow name="salesforce-upsertWithoutHeaders-flow">
-        <salesforce:upsert doc:name="Salesforce" config-ref="Salesforce_Config" objectType="Account" externalIdFieldName="ExternalID__c">
+        <salesforce:upsert doc:name="Salesforce" config-ref="Salesforce_Config" objectType="Account" externalIdFieldName="ExternalID__c" target="payload" targetValue="#[payload.items]">
             <salesforce:records><![CDATA[#[payload]]]></salesforce:records>
         </salesforce:upsert>
 


### PR DESCRIPTION
The output for these three operation was changed from m3 to m4. So, to have the same output after a migration we need to set the payload to payload.items