### PR TITLE
Changing report type due to SonarQuebe changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
                         <execution>
                             <id>default-prepare-agent</id>
                             <goals>
-                                <goal>test</goal>
+                                <goal>prepare-agent</goal>
                             </goals>
                         </execution>
                     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <checksum.plugin.version>1.9</checksum.plugin.version>
 
         <jacoco.maven.plugin.version>0.8.2</jacoco.maven.plugin.version>
-        <jacoco.report.location>${session.executionRootDirectory}/target/jacoco.exec</jacoco.report.location>
+        <jacoco.report.location>${session.executionRootDirectory}/target/site/jacoco/jacoco.xml</jacoco.report.location>
 
         <!-- Dependencies -->
         <gson.version>2.8.6</gson.version>
@@ -293,7 +293,7 @@
                         <execution>
                             <id>default-prepare-agent</id>
                             <goals>
-                                <goal>prepare-agent</goal>
+                                <goal>test</goal>
                             </goals>
                         </execution>
                     </executions>


### PR DESCRIPTION
We need to change the report to XML as the exec type is not reporting coverage anymore. 