### PR TITLE
Add support for migrating MEL with DW function with an inline script

### DIFF
--- a/mule-migration-tool-e2e-tests/src/test/java/com/mulesoft/tools/migration/e2e/DWFunctionMigrationTestCase.java
+++ b/mule-migration-tool-e2e-tests/src/test/java/com/mulesoft/tools/migration/e2e/DWFunctionMigrationTestCase.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020, Mulesoft, LLC. All rights reserved.
+ * Use of this source code is governed by a BSD 3-Clause License
+ * license that can be found in the LICENSE.txt file.
+ */
+package com.mulesoft.tools.migration.e2e;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class DWFunctionMigrationTestCase extends AbstractEndToEndTestCase {
+
+  @Parameters(name = "{0}")
+  public static Object[] params() {
+    return new Object[] {
+        "mel/dw_function"
+    };
+  }
+
+  private final String appToMigrate;
+
+  public DWFunctionMigrationTestCase(String appToMigrate) {
+    this.appToMigrate = appToMigrate;
+  }
+
+  @Test
+  public void test() throws Exception {
+    simpleCase(appToMigrate);
+  }
+}

--- a/mule-migration-tool-e2e-tests/src/test/java/com/mulesoft/tools/migration/e2e/DWFunctionMigrationTestCase.java
+++ b/mule-migration-tool-e2e-tests/src/test/java/com/mulesoft/tools/migration/e2e/DWFunctionMigrationTestCase.java
@@ -5,7 +5,6 @@
  */
 package com.mulesoft.tools.migration.e2e;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/mel/dw_function/input/src/main/app/mule-config.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/mel/dw_function/input/src/main/app/mule-config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:dw="http://www.mulesoft.org/schema/mule/ee/dw" xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+    xmlns:spring="http://www.springframework.org/schema/beans" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd">
+    <http:listener-config name="HTTP_Listener_Configuration" host="0.0.0.0" port="8081" doc:name="HTTP Listener Configuration"/>
+    <flow name="testdwFlow">
+        <http:listener config-ref="HTTP_Listener_Configuration" path="/testdw" doc:name="HTTP"/>
+        <set-variable variableName="applicationProperties" value="#[{&quot;cloudapp.application.md5&quot;: &quot;1234&quot;}]" doc:name="Variable"/>
+        <set-variable variableName="platformApplicationMD5" value="1234" doc:name="Copy_of_Variable"/>
+        <set-payload value="#[dw(&quot;\&quot;Expression value \&quot; ++ (flowVars.applicationProperties.'cloudapp.application.md5' == flowVars.platformApplicationMD5)&quot;)]" doc:name="Set Payload"/>
+    </flow>
+</mule>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/mel/dw_function/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/mel/dw_function/output/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.mule.migrated</groupId>
+  <artifactId>dw_function</artifactId>
+  <version>1.0.0-M4-SNAPSHOT</version>
+  <packaging>mule-application</packaging>
+  <description>Application migrated with MMA</description>
+  <dependencies>
+    <dependency>
+      <groupId>com.mulesoft.mule.modules</groupId>
+      <artifactId>mule-compatibility-module</artifactId>
+      <version>1.4.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.mule.connectors</groupId>
+      <artifactId>mule-http-connector</artifactId>
+      <version>1.6.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+  </dependencies>
+  <repositories>
+    <repository>
+      <id>mulesoft-releases</id>
+      <name>MuleSoft Releases Repository</name>
+      <url>https://repository.mulesoft.org/releases/</url>
+    </repository>
+    <repository>
+      <id>anypoint-exchange</id>
+      <name>Anypoint Exchange</name>
+      <url>https://maven.anypoint.mulesoft.com/api/v1/maven</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>mulesoft-releases</id>
+      <name>MuleSoft Releases Repository</name>
+      <url>https://repository.mulesoft.org/releases/</url>
+    </pluginRepository>
+  </pluginRepositories>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.mule.tools.maven</groupId>
+        <artifactId>mule-maven-plugin</artifactId>
+        <version>3.2.1</version>
+        <extensions>true</extensions>
+        <configuration />
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/mel/dw_function/output/report/report.json
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/mel/dw_function/output/report/report.json
@@ -1,0 +1,85 @@
+{
+  "projectType": "MULE_THREE_APPLICATION",
+  "projectName": "input",
+  "connectorsMigrated": [
+    "org.mule.connectors:mule-http-connector:1.6.0"
+  ],
+  "numberOfMuleComponents": 7,
+  "numberOfMuleComponentsMigrated": 7,
+  "componentDetails": {
+    "mule": {
+      "success": 1,
+      "failure": 0
+    },
+    "flow": {
+      "success": 1,
+      "failure": 0
+    },
+    "set-payload": {
+      "success": 1,
+      "failure": 0
+    },
+    "set-variable": {
+      "success": 2,
+      "failure": 0
+    },
+    "http:listener-config": {
+      "success": 1,
+      "failure": 0
+    },
+    "http:listener": {
+      "success": 1,
+      "failure": 0
+    }
+  },
+  "numberOfMELExpressions": 2,
+  "numberOfMELExpressionsMigrated": 2,
+  "numberOfMELExpressionLines": 2,
+  "numberOfMELExpressionLinesMigrated": 2,
+  "numberOfDWTransformations": 0,
+  "numberOfDWTransformationsMigrated": 0,
+  "numberOfDWTransformationLines": 0,
+  "numberOfDWTransformationLinesMigrated": 0,
+  "detailedMessages": [
+    {
+      "level": "WARN",
+      "key": "http.statusCode",
+      "component": "http:response",
+      "lineNumber": 10,
+      "columnNumber": 113,
+      "message": "Avoid using an outbound property to determine the status code.",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    },
+    {
+      "level": "WARN",
+      "key": "http.statusCode",
+      "component": "http:error-response",
+      "lineNumber": 16,
+      "columnNumber": 141,
+      "message": "Avoid using an outbound property to determine the status code.",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    },
+    {
+      "level": "WARN",
+      "key": "message.attributesToInboundProperties",
+      "component": "compatibility:attributes-to-inbound-properties",
+      "lineNumber": 24,
+      "columnNumber": 57,
+      "message": "Expressions that query \u0027inboundProperties\u0027 from the message should instead query the message \u0027attributes\u0027. Remove this component if there are no uses of \u0027inboundProperties\u0027 in expressions or components that rely on \u0027inboundProperties\u0027 (such as \u0027copy-properties\u0027).",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    },
+    {
+      "level": "WARN",
+      "key": "message.outboundProperties",
+      "component": "compatibility:outbound-properties-to-var",
+      "lineNumber": 37,
+      "columnNumber": 51,
+      "message": "Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as \u0027method\u0027) of the operation or listener that accepts the expression.",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    }
+  ]
+}

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/mel/dw_function/output/src/main/mule/mule-config.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/mel/dw_function/output/src/main/mule/mule-config.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:compatibility="http://www.mulesoft.org/schema/mule/compatibility" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd http://www.mulesoft.org/schema/mule/compatibility http://www.mulesoft.org/schema/mule/compatibility/current/mule-compatibility.xsd http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <http:listener-config name="HTTP_Listener_Configuration" doc:name="HTTP Listener Configuration">
+        <http:listener-connection host="0.0.0.0" port="8081" />
+    </http:listener-config>
+
+    <flow name="testdwFlow">
+        <http:listener config-ref="HTTP_Listener_Configuration" path="/testdw" doc:name="HTTP">
+            <http:response statusCode="#[migration::HttpListener::httpListenerResponseSuccessStatusCode(vars)]">
+                <!--Migration WARN: Avoid using an outbound property to determine the status code.-->
+                <!--    For more information refer to:-->
+                <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool-post-mig.adoc#outbound_properties-->
+                <http:headers>#[migration::HttpListener::httpListenerResponseHeaders(vars)]</http:headers>
+            </http:response>
+            <http:error-response statusCode="#[vars.statusCode default migration::HttpListener::httpListenerResponseErrorStatusCode(vars)]">
+                <!--Migration WARN: Avoid using an outbound property to determine the status code.-->
+                <!--    For more information refer to:-->
+                <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool-post-mig.adoc#outbound_properties-->
+                <http:headers>#[migration::HttpListener::httpListenerResponseHeaders(vars)]</http:headers>
+            </http:error-response>
+        </http:listener>
+
+        <compatibility:attributes-to-inbound-properties>
+            <!--Migration WARN: Expressions that query 'inboundProperties' from the message should instead query the message 'attributes'. Remove this component if there are no uses of 'inboundProperties' in expressions or components that rely on 'inboundProperties' (such as 'copy-properties').-->
+            <!--    For more information refer to:-->
+            <!--        * https://docs.mulesoft.com/mule-runtime/4.3/intro-mule-message#inbound-properties-are-now-attributes-->
+            <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool-post-mig.adoc#inbound_properties-->
+        </compatibility:attributes-to-inbound-properties>
+
+        <set-variable variableName="applicationProperties" value="#[{   &quot;cloudapp.application.md5&quot;: '1234' }]" doc:name="Variable" />
+
+        <set-variable variableName="platformApplicationMD5" value="1234" doc:name="Copy_of_Variable" />
+
+        <set-payload value="#[&quot;Expression value &quot; ++ (vars.applicationProperties.&quot;cloudapp.application.md5&quot; == vars.platformApplicationMD5)]" doc:name="Set Payload" />
+
+        <compatibility:outbound-properties-to-var>
+            <!--Migration WARN: Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as 'method') of the operation or listener that accepts the expression.-->
+            <!--    For more information refer to:-->
+            <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool-post-mig.adoc#outbound_properties-->
+        </compatibility:outbound-properties-to-var>
+
+    </flow>
+
+</mule>

--- a/mule-migration-tool-expression/pom.xml
+++ b/mule-migration-tool-expression/pom.xml
@@ -119,6 +119,10 @@
             <groupId>org.mule.weave</groupId>
             <artifactId>parser</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mule.weave</groupId>
+            <artifactId>migrant</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/mule-migration-tool-expression/src/main/scala/com/mulesoft/tools/MelGrammar.scala
+++ b/mule-migration-tool-expression/src/main/scala/com/mulesoft/tools/MelGrammar.scala
@@ -213,8 +213,8 @@ class MelGrammar(val input: ParserInput) extends Parser with StringBuilding {
     ws ~ ch('\'') ~ clearSB() ~ zeroOrMore(doubleQuoteEscapedChar | noneOf("\'") ~ appendSB()) ~ ch('\'') ~ push(sb.toString) ~> createStringNode
   }
 
-  def stringPreserveEscaping = rule {
-    capture(zeroOrMore(doubleQuoteEscapedChar() | noneOf("\""))) ~> (_.replace("\\\"", "\""))
+  def stringNodePreserveEscaping = rule {
+    ws ~ ch('"') ~ capture(zeroOrMore(doubleQuoteEscapedChar() | noneOf("\""))) ~> (_.replace("\\\"", "\"")) ~  ws ~ ch('"') ~> createStringNode
   }
 
   def doubleQuoteEscapedChar() = rule {
@@ -250,7 +250,7 @@ class MelGrammar(val input: ParserInput) extends Parser with StringBuilding {
   }
 
   def values = rule {
-    (property | constructor | dwMethodInvocation | methodInvocation  | stringNode | stringNodeSimple | list | map | varReference | enclosedExpression) ~ zeroOrMore(selector)
+    (property | constructor | methodInvocation  | stringNodePreserveEscaping | stringNodeSimple | list | map | varReference | enclosedExpression) ~ zeroOrMore(selector)
   }
 
   def constructor: Rule1[ConstructorNode] = rule {
@@ -259,14 +259,6 @@ class MelGrammar(val input: ParserInput) extends Parser with StringBuilding {
 
   def containsToken = rule {
     ws ~ "contains"
-  }
-
-  def dwScript = rule {
-    ws ~ str("\"") ~ stringPreserveEscaping ~ str("\"") ~> createStringNode
-  }
-
-  def dwMethodInvocation: Rule1[DWFunctionNode] = rule {
-    ws ~ str("dw") ~ ws ~ ch('(') ~ ws ~ dwScript ~ ws ~ ch(')') ~> createDWMethodInvocationNode
   }
 
   def methodInvocation = rule {

--- a/mule-migration-tool-expression/src/main/scala/com/mulesoft/tools/MelGrammar.scala
+++ b/mule-migration-tool-expression/src/main/scala/com/mulesoft/tools/MelGrammar.scala
@@ -17,6 +17,7 @@ class MelGrammar(val input: ParserInput) extends Parser with StringBuilding {
   private val createListNode = (elements: Seq[MelExpressionNode]) => ListNode(elements)
   private val createConstructorNode = (canonicalName: CanonicalNameNode, arguments: Seq[MelExpressionNode]) => ConstructorNode(canonicalName, arguments)
   private val createMethodInvocationNode = (canonicalName: CanonicalNameNode, arguments: Seq[MelExpressionNode]) => MethodInvocationNode(canonicalName, arguments)
+  private val createDWMethodInvocationNode = (script: StringNode) => DWFunctionNode(script)
   private val createCanonicalNameNode = (name: String) => CanonicalNameNode(name)
   private val createIfNode = (condition : MelExpressionNode, ifExpr : MelExpressionNode, elseExpr : MelExpressionNode) => IfNode(ifExpr, condition, elseExpr)
   private val createPropertyNode = (identifiers: Seq[IdentifierNode]) => PropertyNode(identifiers)
@@ -212,6 +213,10 @@ class MelGrammar(val input: ParserInput) extends Parser with StringBuilding {
     ws ~ ch('\'') ~ clearSB() ~ zeroOrMore(doubleQuoteEscapedChar | noneOf("\'") ~ appendSB()) ~ ch('\'') ~ push(sb.toString) ~> createStringNode
   }
 
+  def stringPreserveEscaping = rule {
+    capture(zeroOrMore(doubleQuoteEscapedChar() | noneOf("\""))) ~> (_.replace("\\\"", "\""))
+  }
+
   def doubleQuoteEscapedChar() = rule {
     str("\\\"")
   }
@@ -245,7 +250,7 @@ class MelGrammar(val input: ParserInput) extends Parser with StringBuilding {
   }
 
   def values = rule {
-    (property | constructor | methodInvocation | stringNode | stringNodeSimple | list | map | varReference | enclosedExpression) ~ zeroOrMore(selector)
+    (property | constructor | dwMethodInvocation | methodInvocation  | stringNode | stringNodeSimple | list | map | varReference | enclosedExpression) ~ zeroOrMore(selector)
   }
 
   def constructor: Rule1[ConstructorNode] = rule {
@@ -254,6 +259,14 @@ class MelGrammar(val input: ParserInput) extends Parser with StringBuilding {
 
   def containsToken = rule {
     ws ~ "contains"
+  }
+
+  def dwScript = rule {
+    ws ~ str("\"") ~ stringPreserveEscaping ~ str("\"") ~> createStringNode
+  }
+
+  def dwMethodInvocation: Rule1[DWFunctionNode] = rule {
+    ws ~ str("dw") ~ ws ~ ch('(') ~ ws ~ dwScript ~ ws ~ ch(')') ~> createDWMethodInvocationNode
   }
 
   def methodInvocation = rule {

--- a/mule-migration-tool-expression/src/main/scala/com/mulesoft/tools/MigrationResult.scala
+++ b/mule-migration-tool-expression/src/main/scala/com/mulesoft/tools/MigrationResult.scala
@@ -1,27 +1,17 @@
 package com.mulesoft.tools
 
+import com.mulesoft.tools.Migrator.DEFAULT_HEADER
 import org.mule.weave.v2.codegen.CodeGenerator
 import org.mule.weave.v2.parser.ast.header.HeaderNode
-import org.mule.weave.v2.parser.ast.header.directives.{VersionDirective, VersionMajor, VersionMinor}
 import org.mule.weave.v2.parser.{ast => dw}
 
 class MigrationResult(val dwAstNode: dw.AstNode, val metadata: MigrationMetadata = Empty()) {
-  val DEFAULT_HEADER = HeaderNode(Seq(VersionDirective(VersionMajor("2"), VersionMinor("0"))))
 
   def getGeneratedCode(headerNode: HeaderNode): String = {
     CodeGenerator.generate(dw.structure.DocumentNode(headerNode, dwAstNode))
   }
 
   def getGeneratedCode(): String = {
-    // avoid duplicating DW header
-    if (defaultHeaderAlreadyDefined(dwAstNode)) {
-      return CodeGenerator.generate(dwAstNode)
-    }
-
     getGeneratedCode(DEFAULT_HEADER)
-  }
-
-  private def defaultHeaderAlreadyDefined(root: dw.AstNode): Boolean = {
-    Option(dwAstNode.children()).isDefined && !dwAstNode.children().isEmpty && dwAstNode.children().head == DEFAULT_HEADER
   }
 }

--- a/mule-migration-tool-expression/src/main/scala/com/mulesoft/tools/MigrationResult.scala
+++ b/mule-migration-tool-expression/src/main/scala/com/mulesoft/tools/MigrationResult.scala
@@ -13,6 +13,15 @@ class MigrationResult(val dwAstNode: dw.AstNode, val metadata: MigrationMetadata
   }
 
   def getGeneratedCode(): String = {
+    // avoid duplicating DW header
+    if (defaultHeaderAlreadyDefined(dwAstNode)) {
+      return CodeGenerator.generate(dwAstNode)
+    }
+
     getGeneratedCode(DEFAULT_HEADER)
+  }
+
+  private def defaultHeaderAlreadyDefined(root: dw.AstNode): Boolean = {
+    Option(dwAstNode.children()).isDefined && !dwAstNode.children().isEmpty && dwAstNode.children().head == DEFAULT_HEADER
   }
 }

--- a/mule-migration-tool-expression/src/main/scala/com/mulesoft/tools/ast/MelExpressionNode.scala
+++ b/mule-migration-tool-expression/src/main/scala/com/mulesoft/tools/ast/MelExpressionNode.scala
@@ -54,7 +54,8 @@ case class PropertyNode(name: Seq[IdentifierNode]) extends MelExpressionNode {
 case class ContainsNode(left: MelExpressionNode, right: MelExpressionNode) extends MelExpressionNode {
 }
 
-
+case class DWFunctionNode(script: StringNode) extends MelExpressionNode {
+}
 
 object OperatorType {
   val plus = 0

--- a/mule-migration-tool-expression/src/test/scala/com/mulesoft/tools/MigratorTest.scala
+++ b/mule-migration-tool-expression/src/test/scala/com/mulesoft/tools/MigratorTest.scala
@@ -172,11 +172,19 @@ class MigratorTest extends FlatSpec with Matchers {
     Migrator.migrate("dw(\"\\\"Expression is \\\" ++ (flowVars.firstVar == flowVars.secondVar)\")").getGeneratedCode() shouldBe "%dw 2.0\n---\n\"Expression is \" ++ (vars.firstVar == vars.secondVar)"
   }
 
+  it should "migrate a dw function with single quotes" in {
+    Migrator.migrate("dw(\'\"Expression is \" ++ (flowVars.firstVar == flowVars.secondVar)\')").getGeneratedCode() shouldBe "%dw 2.0\n---\n\"Expression is \" ++ (vars.firstVar == vars.secondVar)"
+  }
+
   it should "migrate a dw function with conditional statement" in {
     Migrator.migrate("dw(\"{md5: 1234} when flowVars.firstVar == flowVars.secondVar otherwise {md5: 456}\")").getGeneratedCode() shouldBe "%dw 2.0\n---\nif (vars.firstVar == vars.secondVar)\n  {\n    md5: 1234\n  }\nelse\n  {\n    md5: 456\n  }"
   }
 
   it should "migrate mel expression involving dw function" in {
     Migrator.migrate("\"Value of variable is: \" + dw(\"{md5: 1234} when flowVars.firstVar == flowVars.secondVar otherwise {md5: 456}\")").getGeneratedCode() shouldBe "%dw 2.0\n---\n'Value of variable is: ' ++ if (vars.firstVar == vars.secondVar)\n  {\n    md5: 1234\n  }\nelse\n  {\n    md5: 456\n  }"
+  }
+
+  it should "fail with dw function with no inline script" in {
+    Migrator.migrate("dw(flowVars.test)").metadata.children.head shouldBe NonMigratable("expressions.methodInvocation")
   }
 }

--- a/mule-migration-tool-expression/src/test/scala/com/mulesoft/tools/MigratorTest.scala
+++ b/mule-migration-tool-expression/src/test/scala/com/mulesoft/tools/MigratorTest.scala
@@ -175,4 +175,8 @@ class MigratorTest extends FlatSpec with Matchers {
   it should "migrate a dw function with conditional statement" in {
     Migrator.migrate("dw(\"{md5: 1234} when flowVars.firstVar == flowVars.secondVar otherwise {md5: 456}\")").getGeneratedCode() shouldBe "%dw 2.0\n---\nif (vars.firstVar == vars.secondVar)\n  {\n    md5: 1234\n  }\nelse\n  {\n    md5: 456\n  }"
   }
+
+  it should "migrate mel expression involving dw function" in {
+    Migrator.migrate("\"Value of variable is: \" + dw(\"{md5: 1234} when flowVars.firstVar == flowVars.secondVar otherwise {md5: 456}\")").getGeneratedCode() shouldBe "%dw 2.0\n---\n'Value of variable is: ' ++ if (vars.firstVar == vars.secondVar)\n  {\n    md5: 1234\n  }\nelse\n  {\n    md5: 456\n  }"
+  }
 }

--- a/mule-migration-tool-expression/src/test/scala/com/mulesoft/tools/MigratorTest.scala
+++ b/mule-migration-tool-expression/src/test/scala/com/mulesoft/tools/MigratorTest.scala
@@ -167,4 +167,12 @@ class MigratorTest extends FlatSpec with Matchers {
   it should "migrate a simple ternary operator expression2" in {
     Migrator.migrate("true ? true ? 1 : 0 : 0").getGeneratedCode() shouldBe "%dw 2.0\n---\nif (true)\n  if (true)\n    1\n  else\n    0\nelse\n  0"
   }
+
+  it should "migrate a dw function" in {
+    Migrator.migrate("dw(\"\\\"Expression is \\\" ++ (flowVars.firstVar == flowVars.secondVar)\")").getGeneratedCode() shouldBe "%dw 2.0\n---\n\"Expression is \" ++ (vars.firstVar == vars.secondVar)"
+  }
+
+  it should "migrate a dw function with conditional statement" in {
+    Migrator.migrate("dw(\"{md5: 1234} when flowVars.firstVar == flowVars.secondVar otherwise {md5: 456}\")").getGeneratedCode() shouldBe "%dw 2.0\n---\nif (vars.firstVar == vars.secondVar)\n  {\n    md5: 1234\n  }\nelse\n  {\n    md5: 456\n  }"
+  }
 }


### PR DESCRIPTION
This change allows migrating expressions like:
```
        <set-payload value="#[dw(&quot;\&quot;Expression value \&quot; ++ (flowVars.applicationProperties.'cloudapp.application.md5' == flowVars.platformApplicationMD5)&quot;)]" doc:name="Set Payload"/>
```

which will be migrated to:

```
        <set-payload value="#[&quot;Expression value &quot; ++ (vars.applicationProperties.&quot;cloudapp.application.md5&quot; == vars.platformApplicationMD5)]" doc:name="Set Payload" />

```

Also expressions that contain both MEL code and an embedded dw function will be migrated