### PR TITLE
Add generic unsupported elements handling steps and implement the fist use for the Salesforce connector

### DIFF
--- a/mule-migration-tool-api/src/main/java/com/mulesoft/tools/migration/step/AbstractUnsupportedElementsMigrationStep.java
+++ b/mule-migration-tool-api/src/main/java/com/mulesoft/tools/migration/step/AbstractUnsupportedElementsMigrationStep.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020, Mulesoft, LLC. All rights reserved.
+ * Use of this source code is governed by a BSD 3-Clause License
+ * license that can be found in the LICENSE.txt file.
+ */
+package com.mulesoft.tools.migration.step;
+
+import com.mulesoft.tools.migration.step.category.MigrationReport;
+import com.mulesoft.tools.migration.step.util.XmlDslUtils;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Lists.newArrayList;
+
+/**
+ * Takes unsupported or blocked elements and comments them, mark them as failed
+ *
+ * @author Mulesoft Inc.
+ * @since 1.0.0
+ */
+public abstract class AbstractUnsupportedElementsMigrationStep extends AbstractApplicationModelMigrationStep {
+
+  public static final String COMPONENTS_UNSUPPORTED_ERROR_KEY = "components.unsupported";
+  public static final String NAME_ATTRIBUTE_TEMPLATE = "(name = %s)";
+
+  public AbstractUnsupportedElementsMigrationStep(Namespace namespace) {
+    checkArgument(getUnsupportedElements() != null, "The unsupported elements list must not be null.");
+    this.setAppliedTo(XmlDslUtils.getAllElementsFromNamespaceXpathSelector(namespace.getURI(), false));
+    this.setNamespacesContributions(newArrayList(namespace));
+  }
+
+  public abstract List<String> getUnsupportedElements();
+
+  @Override
+  public void execute(Element node, MigrationReport report) throws RuntimeException {
+    if (getUnsupportedElements().contains(node.getName())) {
+      report.report(COMPONENTS_UNSUPPORTED_ERROR_KEY, node, node.getParentElement(),
+                    report.getComponentKey(node) + " " + String.format(NAME_ATTRIBUTE_TEMPLATE, node.getAttributeValue("name")));
+      node.getParentElement().removeChild(node.getName(), node.getNamespace());
+    }
+  }
+}

--- a/mule-migration-tool-api/src/main/java/com/mulesoft/tools/migration/step/category/MigrationReport.java
+++ b/mule-migration-tool-api/src/main/java/com/mulesoft/tools/migration/step/category/MigrationReport.java
@@ -133,6 +133,8 @@ public interface MigrationReport<T> {
    */
   Map<String, ComponentMigrationStatus> getComponents();
 
+  String getComponentKey(Element element);
+
   /**
    * Increments the component success migration count.
    *

--- a/mule-migration-tool-api/src/main/java/com/mulesoft/tools/migration/step/util/XmlDslUtils.java
+++ b/mule-migration-tool-api/src/main/java/com/mulesoft/tools/migration/step/util/XmlDslUtils.java
@@ -739,6 +739,17 @@ public final class XmlDslUtils {
   }
 
   /**
+   * Get Xpath expression to select all elements from a given namespace on the configuration file
+   *
+   * @param namespaceUri the namespace URI
+   * @param topLevel is a top level element
+   * @return a String with the expression
+   */
+  public static String getAllElementsFromNamespaceXpathSelector(String namespaceUri, boolean topLevel) {
+    return format("%s[namespace-uri() = '%s']", topLevel ? "/*/*" : "//*", namespaceUri);
+  }
+
+  /**
    * Get Xpath expression to select Mule core elements on the configuration file
    *
    * @param elementName the element name

--- a/mule-migration-tool-api/src/test/java/com/mulesoft/tools/migration/step/AbstractUnsupportedElementsMigrationStepTest.java
+++ b/mule-migration-tool-api/src/test/java/com/mulesoft/tools/migration/step/AbstractUnsupportedElementsMigrationStepTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020, Mulesoft, LLC. All rights reserved.
+ * Use of this source code is governed by a BSD 3-Clause License
+ * license that can be found in the LICENSE.txt file.
+ */
+package com.mulesoft.tools.migration.step;
+
+import com.google.common.collect.ImmutableList;
+import com.mulesoft.tools.migration.step.category.MigrationReport;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.mulesoft.tools.migration.step.AbstractUnsupportedElementsMigrationStep.COMPONENTS_UNSUPPORTED_ERROR_KEY;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * @author Mulesoft Inc.
+ */
+public class AbstractUnsupportedElementsMigrationStepTest {
+
+  public static final Namespace TEST_NAMESPACE = Namespace.getNamespace("test", "http://test.com");
+
+  private AbstractUnsupportedElementsMigrationStep migrationStep;
+  private Element elementMock;
+  private Element parentElementMock;
+  private MigrationReport reportMock;
+  private static final String BLOCKED_ELEMENT_NAME = "blocked";
+
+  @Before
+  public void setUp() throws Exception {
+    migrationStep = new AbstractUnsupportedElementsMigrationStepTest.MigrationStepImpl();
+    elementMock = mock(Element.class);
+    parentElementMock = mock(Element.class);
+    when(elementMock.getName()).thenReturn(BLOCKED_ELEMENT_NAME);
+    when(elementMock.getParentElement()).thenReturn(parentElementMock);
+    when(elementMock.getNamespace()).thenReturn(TEST_NAMESPACE);
+    reportMock = mock(MigrationReport.class);
+    when(reportMock.getComponentKey(elementMock)).thenReturn(BLOCKED_ELEMENT_NAME);
+  }
+
+  @Test
+  public void testExecute_handleUnsupported() {
+    migrationStep.execute(elementMock, reportMock);
+    verify(reportMock).report(eq(COMPONENTS_UNSUPPORTED_ERROR_KEY), eq(elementMock), eq(parentElementMock), isA(String.class));
+    verify(parentElementMock).removeChild(eq(BLOCKED_ELEMENT_NAME), eq(TEST_NAMESPACE));
+  }
+
+  @Test
+  public void testExecute_handleAllSupported() {
+    when(elementMock.getName()).thenReturn("another_supported_element");
+    migrationStep.execute(elementMock, reportMock);
+    verifyZeroInteractions(reportMock);
+    verifyZeroInteractions(parentElementMock);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testExecute_NullUnsupportedList() {
+    new AbstractUnsupportedElementsMigrationStep(TEST_NAMESPACE) {
+
+      @Override
+      public List<String> getUnsupportedElements() {
+        return null;
+      }
+    }.execute(elementMock, reportMock);
+  }
+
+  private static final class MigrationStepImpl extends AbstractUnsupportedElementsMigrationStep {
+
+    public MigrationStepImpl() {
+      super(TEST_NAMESPACE);
+    }
+
+    @Override
+    public List<String> getUnsupportedElements() {
+      return ImmutableList.of(BLOCKED_ELEMENT_NAME);
+    }
+  }
+}

--- a/mule-migration-tool-e2e-tests/src/test/java/com/mulesoft/tools/migration/e2e/MigrationGapsTestCase.java
+++ b/mule-migration-tool-e2e-tests/src/test/java/com/mulesoft/tools/migration/e2e/MigrationGapsTestCase.java
@@ -18,7 +18,8 @@ public class MigrationGapsTestCase extends AbstractEndToEndTestCase {
   public static Object[] params() {
     return new Object[] {
         "gaps/unknown_element",
-        "gaps/unknown_namespace"
+        "gaps/unknown_namespace",
+        "gaps/salesforce_config_oauth_user_pass"
     };
   }
 

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/salesforce_config_oauth_user_pass/input/src/main/app/mule-config.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/salesforce_config_oauth_user_pass/input/src/main/app/mule-config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" 
+      xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" 
+      xmlns:sfdc="http://www.mulesoft.org/schema/mule/sfdc" 
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+    <sfdc:config-oauth-user-pass name="Salesforce__Basic_Authentication"
+                    consumerKey="${cbms.sfdc.consumerkey}" consumerSecret="${cbms.sfdc.consumersecret}"
+                    username="${cbms.sfdc.username}" password="${cbms.sfdc.password}"
+                    securityToken="${cbms.sfdc.securitytoken}" tokenEndpoint="${cbms.sfdc.authurl}"
+                    doc:name="ct_salesforce" readTimeout="${cbms.sfdc.read.timeout}"
+                    disableSessionInvalidation="true">
+                    <reconnect count="${cbms.sfdc.reconnect.attemptcount}"
+                            frequency="${cbms.sfdc.reconnect.frequency}" />
+    </sfdc:config-oauth-user-pass>
+
+    <sfdc:config-oauth-user-pass name="Salesforce__Basic_Authentication2"
+                                 consumerKey="${cbms.sfdc.consumerkey}" consumerSecret="${cbms.sfdc.consumersecret}"
+                                 username="${cbms.sfdc.username}" password="${cbms.sfdc.password}"
+                                 securityToken="${cbms.sfdc.securitytoken}" tokenEndpoint="${cbms.sfdc.authurl}"
+                                 doc:name="ct_salesforce" readTimeout="${cbms.sfdc.read.timeout}"
+                                 disableSessionInvalidation="true">
+        <reconnect count="${cbms.sfdc.reconnect.attemptcount}"
+                   frequency="${cbms.sfdc.reconnect.frequency}" />
+    </sfdc:config-oauth-user-pass>
+</mule>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/salesforce_config_oauth_user_pass/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/salesforce_config_oauth_user_pass/output/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.mule.migrated</groupId>
+  <artifactId>salesforce_config_oauth_user_pass</artifactId>
+  <version>1.0.0-M4-SNAPSHOT</version>
+  <packaging>mule-application</packaging>
+  <description>Application migrated with MMA</description>
+  <dependencies>
+    <dependency>
+      <groupId>com.mulesoft.mule.modules</groupId>
+      <artifactId>mule-compatibility-module</artifactId>
+      <version>1.4.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
+      <groupId>com.mulesoft.connectors</groupId>
+      <artifactId>mule-salesforce-connector</artifactId>
+      <version>10.14.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+  </dependencies>
+  <repositories>
+    <repository>
+      <id>mulesoft-releases</id>
+      <name>MuleSoft Releases Repository</name>
+      <url>https://repository.mulesoft.org/releases/</url>
+    </repository>
+    <repository>
+      <id>anypoint-exchange</id>
+      <name>Anypoint Exchange</name>
+      <url>https://maven.anypoint.mulesoft.com/api/v1/maven</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>mulesoft-releases</id>
+      <name>MuleSoft Releases Repository</name>
+      <url>https://repository.mulesoft.org/releases/</url>
+    </pluginRepository>
+  </pluginRepositories>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.mule.tools.maven</groupId>
+        <artifactId>mule-maven-plugin</artifactId>
+        <version>3.2.1</version>
+        <extensions>true</extensions>
+        <configuration />
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/salesforce_config_oauth_user_pass/output/report/report.json
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/salesforce_config_oauth_user_pass/output/report/report.json
@@ -1,0 +1,49 @@
+{
+  "projectType": "MULE_THREE_APPLICATION",
+  "projectName": "input",
+  "connectorsMigrated": [
+    "com.mulesoft.connectors:mule-salesforce-connector:10.14.0"
+  ],
+  "numberOfMuleComponents": 3,
+  "numberOfMuleComponentsMigrated": 1,
+  "componentDetails": {
+    "mule": {
+      "success": 1,
+      "failure": 0
+    },
+    "sfdc:config-oauth-user-pass": {
+      "success": 0,
+      "failure": 2
+    }
+  },
+  "numberOfMELExpressions": 0,
+  "numberOfMELExpressionsMigrated": 0,
+  "numberOfMELExpressionLines": 0,
+  "numberOfMELExpressionLinesMigrated": 0,
+  "numberOfDWTransformations": 0,
+  "numberOfDWTransformationsMigrated": 0,
+  "numberOfDWTransformationLines": 0,
+  "numberOfDWTransformationLinesMigrated": 0,
+  "detailedMessages": [
+    {
+      "level": "ERROR",
+      "key": "components.unsupported",
+      "component": "mule",
+      "lineNumber": 2,
+      "columnNumber": 292,
+      "message": "The migration of \u0027sfdc:config-oauth-user-pass (name = Salesforce__Basic_Authentication)\u0027 is not supported.",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    },
+    {
+      "level": "ERROR",
+      "key": "components.unsupported",
+      "component": "mule",
+      "lineNumber": 2,
+      "columnNumber": 292,
+      "message": "The migration of \u0027sfdc:config-oauth-user-pass (name = Salesforce__Basic_Authentication2)\u0027 is not supported.",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    }
+  ]
+}

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/salesforce_config_oauth_user_pass/output/src/main/mule/mule-config.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/salesforce_config_oauth_user_pass/output/src/main/mule/mule-config.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <!--Migration ERROR: The migration of 'sfdc:config-oauth-user-pass' (name Salesforce__Basic_Authentication) is not supported.-->
+    <!--    For more information refer to:-->
+    <!--        * https://docs.mulesoft.com/mule-runtime/4.3/migration-connectors-->
+    <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool.adoc#unsupported_connectors-->
+    <!--<sfdc:config-oauth-user-pass xmlns:sfdc="http://www.mulesoft.org/schema/mule/sfdc" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" name="Salesforce__Basic_Authentication" consumerKey="${cbms.sfdc.consumerkey}" consumerSecret="${cbms.sfdc.consumersecret}" username="${cbms.sfdc.username}" password="${cbms.sfdc.password}" securityToken="${cbms.sfdc.securitytoken}" tokenEndpoint="${cbms.sfdc.authurl}" doc:name="ct_salesforce" readTimeout="${cbms.sfdc.read.timeout}" disableSessionInvalidation="true">
+        <reconnect xmlns="http://www.mulesoft.org/schema/mule/core" count="${cbms.sfdc.reconnect.attemptcount}" frequency="${cbms.sfdc.reconnect.frequency}" />
+    </sfdc:config-oauth-user-pass>-->
+
+    <!--Migration ERROR: The migration of 'sfdc:config-oauth-user-pass' (name Salesforce__Basic_Authentication2) is not supported.-->
+    <!--    For more information refer to:-->
+    <!--        * https://docs.mulesoft.com/mule-runtime/4.3/migration-connectors-->
+    <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool.adoc#unsupported_connectors-->
+    <!--<sfdc:config-oauth-user-pass xmlns:sfdc="http://www.mulesoft.org/schema/mule/sfdc" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" name="Salesforce__Basic_Authentication" consumerKey="${cbms.sfdc.consumerkey}" consumerSecret="${cbms.sfdc.consumersecret}" username="${cbms.sfdc.username}" password="${cbms.sfdc.password}" securityToken="${cbms.sfdc.securitytoken}" tokenEndpoint="${cbms.sfdc.authurl}" doc:name="ct_salesforce" readTimeout="${cbms.sfdc.read.timeout}" disableSessionInvalidation="true">
+        <reconnect xmlns="http://www.mulesoft.org/schema/mule/core" count="${cbms.sfdc.reconnect.attemptcount}" frequency="${cbms.sfdc.reconnect.frequency}" />
+    </sfdc:config-oauth-user-pass>-->
+</mule>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/unknown_element/output/report/report.json
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/unknown_element/output/report/report.json
@@ -26,5 +26,6 @@
   "numberOfDWTransformationsMigrated": 0,
   "numberOfDWTransformationLines": 0,
   "numberOfDWTransformationLinesMigrated": 0,
-  "detailedMessages": []
+  "detailedMessages": [
+  ]
 }

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/unknown_element/output/src/main/mule/mule-config.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/unknown_element/output/src/main/mule/mule-config.xml
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
     <flow name="unknown-elements">
         <unknown-source>
-            <logger message="nested" />
-            <unknown-nested />
+            <logger message="nested"/>
+            <unknown-nested/>
         </unknown-source>
-
-        <logger message="bye" />
-
-        <unknown-operation />
-
+        <logger message="bye"/>
+        <unknown-operation/>
     </flow>
 
 </mule>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/unknown_namespace/output/report/report.json
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/unknown_namespace/output/report/report.json
@@ -2,8 +2,8 @@
   "projectType": "MULE_THREE_APPLICATION",
   "projectName": "input",
   "connectorsMigrated": [],
-  "numberOfMuleComponents": 6,
-  "numberOfMuleComponentsMigrated": 4,
+  "numberOfMuleComponents": 5,
+  "numberOfMuleComponentsMigrated": 3,
   "componentDetails": {
     "unknown:source": {
       "success": 0,
@@ -18,7 +18,7 @@
       "failure": 0
     },
     "logger": {
-      "success": 2,
+      "success": 1,
       "failure": 0
     },
     "flow": {
@@ -38,22 +38,24 @@
     {
       "level": "ERROR",
       "key": "components.unsupported",
-      "component": "unknown:source",
-      "lineNumber": 5,
-      "columnNumber": 25,
-      "message": "The migration of \u0027unknown\u0027 is not supported.",
+      "component": "flow",
+      "lineNumber": 4,
+      "columnNumber": 36,
+      "message": "The migration of 'namespace unknown (element operation)' is not supported.",
       "filePath": "src/main/mule/mule-config.xml",
-      "documentationLinks": []
+      "documentationLinks":
+      []
     },
     {
       "level": "ERROR",
       "key": "components.unsupported",
-      "component": "unknown:operation",
-      "lineNumber": 16,
-      "columnNumber": 28,
-      "message": "The migration of \u0027unknown\u0027 is not supported.",
+      "component": "flow",
+      "lineNumber": 4,
+      "columnNumber": 36,
+      "message": "The migration of 'namespace unknown (element source)' is not supported.",
       "filePath": "src/main/mule/mule-config.xml",
-      "documentationLinks": []
+      "documentationLinks":
+      []
     }
   ]
 }

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/unknown_namespace/output/src/main/mule/mule-config.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/unknown_namespace/output/src/main/mule/mule-config.xml
@@ -1,25 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:unknown="http://www.mulesoft.org/schema/mule/unknown" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/unknown http://www.mulesoft.org/schema/mule/unknown/current/mule-unknown.xsd http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
     <flow name="unknown-namespace">
-        <unknown:source>
-            <!--Migration ERROR: The migration of 'unknown' is not supported.-->
-            <!--    For more information refer to:-->
-            <!--        * https://docs.mulesoft.com/mule-runtime/4.3/migration-connectors-->
-            <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool.adoc#unsupported_connectors-->
-            <logger message="nested" />
+        <!--Migration ERROR: The migration of 'namespace unknown (element source)' is not supported.-->
+        <!--    For more information refer to:-->
+        <!--        * https://docs.mulesoft.com/mule-runtime/4.3/migration-connectors-->
+        <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool.adoc#unsupported_connectors-->
+        <!--<unknown:source xmlns:unknown="http://www.mulesoft.org/schema/mule/unknown">
+            <logger xmlns="http://www.mulesoft.org/schema/mule/core" message="nested" />
             <unknown:nested />
-        </unknown:source>
-
+        </unknown:source>-->
         <logger message="bye" />
 
-        <unknown:operation>
-            <!--Migration ERROR: The migration of 'unknown' is not supported.-->
-            <!--    For more information refer to:-->
-            <!--        * https://docs.mulesoft.com/mule-runtime/4.3/migration-connectors-->
-            <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool.adoc#unsupported_connectors-->
-        </unknown:operation>
-
+        <!--Migration ERROR: The migration of 'namespace unknown (element operation)' is not supported.-->
+        <!--    For more information refer to:-->
+        <!--        * https://docs.mulesoft.com/mule-runtime/4.3/migration-connectors-->
+        <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool.adoc#unsupported_connectors-->
+        <!--<unknown:operation xmlns:unknown="http://www.mulesoft.org/schema/mule/unknown" />-->
     </flow>
 
 </mule>

--- a/mule-migration-tool-engine/src/main/java/com/mulesoft/tools/migration/report/DefaultMigrationReport.java
+++ b/mule-migration-tool-engine/src/main/java/com/mulesoft/tools/migration/report/DefaultMigrationReport.java
@@ -133,6 +133,10 @@ public class DefaultMigrationReport implements MigrationReport<ReportEntryModel>
     ReportEntryModel reportEntry;
 
     if (elementToComment != null) {
+      if (elementToComment != element) {
+        i = findContentIndex(element, elementToComment);
+      }
+
       if (elementToComment.getDocument() != null || element.getDocument() == null) {
         reportEntry = new ReportEntryModel(entryKey, level, elementToComment, message, documentationLinks);
       } else {
@@ -157,6 +161,15 @@ public class DefaultMigrationReport implements MigrationReport<ReportEntryModel>
       }
     }
 
+  }
+
+  private int findContentIndex(Element element, Element elementToComment) {
+    int i = 0;
+
+    while (i < elementToComment.getContent().size() && !element.toString().equals(elementToComment.getContent(i).toString())) {
+      i++;
+    }
+    return i < elementToComment.getContent().size() ? i : 0;
   }
 
   private String sanitize(String message) {
@@ -239,7 +252,12 @@ public class DefaultMigrationReport implements MigrationReport<ReportEntryModel>
     return components;
   }
 
-  public static String getComponentKey(Element element) {
+  @Override
+  public String getComponentKey(Element element) {
+    return DefaultMigrationReport.getComponentKeyStatic(element);
+  }
+
+  public static String getComponentKeyStatic(Element element) {
     String prefix = StringUtils.isBlank(element.getNamespace().getPrefix()) ? "" : element.getNamespace().getPrefix() + ":";
     return prefix + element.getName();
   }

--- a/mule-migration-tool-engine/src/main/java/com/mulesoft/tools/migration/report/json/JSONReport.java
+++ b/mule-migration-tool-engine/src/main/java/com/mulesoft/tools/migration/report/json/JSONReport.java
@@ -22,7 +22,7 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static com.mulesoft.tools.migration.report.DefaultMigrationReport.getComponentKey;
+import static com.mulesoft.tools.migration.report.DefaultMigrationReport.getComponentKeyStatic;
 
 import org.jdom2.Element;
 
@@ -180,7 +180,7 @@ public class JSONReport extends AbstractReport {
                                  String filePath) {
       this.key = key;
       this.level = level;
-      this.component = component != null ? getComponentKey(component) : "UNKNOWN";
+      this.component = component != null ? getComponentKeyStatic(component) : "UNKNOWN";
       this.lineNumber = lineNumber;
       this.columnNumber = columnNumber;
       this.message = message;

--- a/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/steps/core/PreprocessNamespaces.java
+++ b/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/steps/core/PreprocessNamespaces.java
@@ -18,6 +18,7 @@ import org.jdom2.Document;
 import org.jdom2.Namespace;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -27,6 +28,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @since 1.0.0
  */
 public class PreprocessNamespaces implements NamespaceContribution {
+
+  private static final String UNSUPPORTED_ELEMENT_TEMPLATE = "namespace %s (element %s)";
 
   @Override
   public String getDescription() {
@@ -55,9 +58,14 @@ public class PreprocessNamespaces implements NamespaceContribution {
             processedElements.incrementAndGet();
 
             if (ns.getURI().startsWith("http://www.mulesoft.org")) {
-              report.report("components.unsupported", node, node, ns.getPrefix());
+              report.report("components.unsupported", node, node.getParentElement(),
+                            String.format(UNSUPPORTED_ELEMENT_TEMPLATE, ns.getPrefix(), node.getName()));
+              node.getParentElement().removeChild(node.getName(), ns);
             } else {
-              report.report("components.unknown", node, node, ns.getPrefix(), ns.getURI(), ADDITIONAL_SPRING_NAMESPACES_PROP);
+              report.report("components.unknown", node, node.getParentElement(),
+                            String.format(UNSUPPORTED_ELEMENT_TEMPLATE, ns.getPrefix(), node.getName()),
+                            ns.getURI(), ADDITIONAL_SPRING_NAMESPACES_PROP);
+              node.getParentElement().removeChild(node.getName(), ns);
             }
             report.addComponentFailure(node);
           });

--- a/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/tasks/SalesforceMigrationTask.java
+++ b/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/tasks/SalesforceMigrationTask.java
@@ -75,6 +75,7 @@ public class SalesforceMigrationTask extends AbstractMigrationTask {
                         new ReplayStreamingChannelSource(),
                         new SubscribeTopicSource(),
                         new SubscribeStreamingChannelSource(),
-                        new NonPaginatedQueryOperation());
+                        new NonPaginatedQueryOperation(),
+                        new SalesforceUnsupportedElementsStep());
   }
 }

--- a/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/tasks/SalesforceUnsupportedElementsStep.java
+++ b/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/tasks/SalesforceUnsupportedElementsStep.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020, Mulesoft, LLC. All rights reserved.
+ * Use of this source code is governed by a BSD 3-Clause License
+ * license that can be found in the LICENSE.txt file.
+ */
+package com.mulesoft.tools.migration.library.mule.tasks;
+
+import com.google.common.collect.ImmutableList;
+import com.mulesoft.tools.migration.library.tools.SalesforceUtils;
+import com.mulesoft.tools.migration.step.AbstractUnsupportedElementsMigrationStep;
+
+import java.util.List;
+
+/**
+ * Specific Unsupported Element migration step for Salesforce Connector
+ *
+ * @author Mulesoft Inc.
+ * @since 1.0.0
+ */
+public class SalesforceUnsupportedElementsStep extends AbstractUnsupportedElementsMigrationStep {
+
+  public SalesforceUnsupportedElementsStep() {
+    super(SalesforceUtils.MULE3_SALESFORCE_NAMESPACE);
+  }
+
+  @Override
+  public List<String> getUnsupportedElements() {
+    return ImmutableList.of("config-oauth-user-pass");
+  }
+}


### PR DESCRIPTION
* Also fix unsupported namespace handling to comment unsupported elements instead of leaving them with just an error

On the salesforce connector this is fixing cases using config-oauth-user-pass for now because it was reported but more elements can be added if needed