### PR TITLE
Add scripting dependency when using compatibility

### DIFF
--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/amqp1Mvn/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/amqp1Mvn/output/pom.xml
@@ -22,6 +22,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>com.mulesoft.connectors</groupId>
       <artifactId>mule-amqp-connector</artifactId>
       <version>1.7.3</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/apikit/apikit1/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/apikit/apikit1/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/apikit/apikit2/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/apikit/apikit2/output/pom.xml
@@ -22,6 +22,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/apikit/apikit_soapkit/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/apikit/apikit_soapkit/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/async/async1/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/async/async1/output/pom.xml
@@ -14,6 +14,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/async/async2/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/async/async2/output/pom.xml
@@ -14,6 +14,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/batch/batch1/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/batch/batch1/output/pom.xml
@@ -14,6 +14,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/batch/batch2/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/batch/batch2/output/pom.xml
@@ -14,6 +14,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/cache/cache1/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/cache/cache1/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/cache/cache2/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/cache/cache2/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/cache/cache3/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/cache/cache3/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/choice/choice1/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/choice/choice1/output/pom.xml
@@ -18,6 +18,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>com.mulesoft.munit</groupId>
       <artifactId>munit-runner</artifactId>
       <version>2.3.8</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/choice/choice2/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/choice/choice2/output/pom.xml
@@ -23,6 +23,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>com.mulesoft.munit</groupId>
       <artifactId>munit-runner</artifactId>
       <version>2.3.8</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/compression/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/compression/output/pom.xml
@@ -23,6 +23,12 @@
     </dependency>
     <dependency>
       <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
       <artifactId>mule-compression-module</artifactId>
       <version>2.1.2</version>
       <classifier>mule-plugin</classifier>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/db/db-bulk/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/db/db-bulk/output/pom.xml
@@ -28,6 +28,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-db-connector</artifactId>
       <version>1.12.1</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/db/db-crud/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/db/db-crud/output/pom.xml
@@ -28,6 +28,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-db-connector</artifactId>
       <version>1.12.1</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/db/db-ddl_sp/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/db/db-ddl_sp/output/pom.xml
@@ -28,6 +28,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-db-connector</artifactId>
       <version>1.12.1</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/domain/domain1/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/domain/domain1/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/domain/domain1app1/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/domain/domain1app1/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/ee_transform/ee_transform_01/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/ee_transform/ee_transform_01/output/pom.xml
@@ -1,51 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>org.mule.migrated</groupId>
-    <artifactId>ee_transform_01</artifactId>
-    <version>1.0.0-M4-SNAPSHOT</version>
-    <packaging>mule-application</packaging>
-    <description>Application migrated with MMA</description>
-    <dependencies>
-        <dependency>
-            <groupId>com.mulesoft.mule.modules</groupId>
-            <artifactId>mule-compatibility-module</artifactId>
-            <version>1.4.0</version>
-            <classifier>mule-plugin</classifier>
-        </dependency>
-    </dependencies>
-    <repositories>
-        <repository>
-            <id>mulesoft-releases</id>
-            <name>MuleSoft Releases Repository</name>
-            <url>https://repository.mulesoft.org/releases/</url>
-        </repository>
-        <repository>
-            <id>anypoint-exchange</id>
-            <name>Anypoint Exchange</name>
-            <url>https://maven.anypoint.mulesoft.com/api/v1/maven</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>mulesoft-releases</id>
-            <name>MuleSoft Releases Repository</name>
-            <url>https://repository.mulesoft.org/releases/</url>
-        </pluginRepository>
-    </pluginRepositories>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.mule.tools.maven</groupId>
-                <artifactId>mule-maven-plugin</artifactId>
-                <version>3.2.1</version>
-                <extensions>true</extensions>
-                <configuration />
-            </plugin>
-        </plugins>
-    </build>
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.mule.migrated</groupId>
+  <artifactId>ee_transform_01</artifactId>
+  <version>1.0.0-M4-SNAPSHOT</version>
+  <packaging>mule-application</packaging>
+  <description>Application migrated with MMA</description>
+  <dependencies>
+    <dependency>
+      <groupId>com.mulesoft.mule.modules</groupId>
+      <artifactId>mule-compatibility-module</artifactId>
+      <version>1.4.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+  </dependencies>
+  <repositories>
+    <repository>
+      <id>mulesoft-releases</id>
+      <name>MuleSoft Releases Repository</name>
+      <url>https://repository.mulesoft.org/releases/</url>
+    </repository>
+    <repository>
+      <id>anypoint-exchange</id>
+      <name>Anypoint Exchange</name>
+      <url>https://maven.anypoint.mulesoft.com/api/v1/maven</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>mulesoft-releases</id>
+      <name>MuleSoft Releases Repository</name>
+      <url>https://repository.mulesoft.org/releases/</url>
+    </pluginRepository>
+  </pluginRepositories>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.mule.tools.maven</groupId>
+        <artifactId>mule-maven-plugin</artifactId>
+        <version>3.2.1</version>
+        <extensions>true</extensions>
+        <configuration />
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/ee_transform/ee_transform_02/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/ee_transform/ee_transform_02/output/pom.xml
@@ -14,6 +14,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/ee_transform/ee_transform_03/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/ee_transform/ee_transform_03/output/pom.xml
@@ -14,6 +14,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/ee_transform/ee_transform_keep_parentheses/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/ee_transform/ee_transform_keep_parentheses/output/pom.xml
@@ -14,6 +14,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/email/email1/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/email/email1/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-email-connector</artifactId>
       <version>1.5.2</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/email/email2/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/email/email2/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-email-connector</artifactId>
       <version>1.5.2</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/empty/empty/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/empty/empty/output/pom.xml
@@ -14,6 +14,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/empty/emptyMvn/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/empty/emptyMvn/output/pom.xml
@@ -21,6 +21,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/exceptions/exceptions-01/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/exceptions/exceptions-01/output/pom.xml
@@ -20,6 +20,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/exceptions/exceptions-02/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/exceptions/exceptions-02/output/pom.xml
@@ -21,6 +21,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/exceptions/exceptions-03/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/exceptions/exceptions-03/output/pom.xml
@@ -20,6 +20,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/file/file1/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/file/file1/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-file-connector</artifactId>
       <version>1.3.4</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/file/file2/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/file/file2/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-file-connector</artifactId>
       <version>1.3.4</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/first_successful/first_successful_01/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/first_successful/first_successful_01/output/pom.xml
@@ -14,6 +14,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/for_each/forEach1/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/for_each/forEach1/output/pom.xml
@@ -18,6 +18,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>com.mulesoft.munit</groupId>
       <artifactId>munit-runner</artifactId>
       <version>2.3.8</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/for_each/forEach2/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/for_each/forEach2/output/pom.xml
@@ -23,6 +23,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>com.mulesoft.munit</groupId>
       <artifactId>munit-runner</artifactId>
       <version>2.3.8</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/ftp/ftp-ee/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/ftp/ftp-ee/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-ftp-connector</artifactId>
       <version>1.5.5</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/ftp/ftp/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/ftp/ftp/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-ftp-connector</artifactId>
       <version>1.5.5</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/java/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/java/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/salesforce_config_oauth_user_pass/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/salesforce_config_oauth_user_pass/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>com.mulesoft.connectors</groupId>
       <artifactId>mule-salesforce-connector</artifactId>
       <version>10.14.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/withsampledatafiles/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/gaps/withsampledatafiles/output/pom.xml
@@ -14,6 +14,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/http1/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/http1/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/http1Mvn/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/http1Mvn/output/pom.xml
@@ -22,6 +22,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/http2Mvn/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/http2Mvn/output/pom.xml
@@ -22,6 +22,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/http3Mvn/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/http3Mvn/output/pom.xml
@@ -22,6 +22,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/httpTransport1/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/httpTransport1/output/pom.xml
@@ -16,6 +16,12 @@
     </dependency>
     <dependency>
       <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
       <artifactId>mule-validation-module</artifactId>
       <version>1.4.5</version>
       <classifier>mule-plugin</classifier>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/httpTransport2/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/httpTransport2/output/pom.xml
@@ -16,6 +16,12 @@
     </dependency>
     <dependency>
       <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
       <artifactId>mule-validation-module</artifactId>
       <version>1.4.5</version>
       <classifier>mule-plugin</classifier>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/httpTransport3/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/httpTransport3/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/httpTransport4/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/httpTransport4/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/httpTransport5/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/http/httpTransport5/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/integration/demo_connect/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/integration/demo_connect/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/jms/jms1Mvn/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/jms/jms1Mvn/output/pom.xml
@@ -28,6 +28,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-jms-connector</artifactId>
       <version>1.8.2</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/json/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/json/output/pom.xml
@@ -16,6 +16,12 @@
     </dependency>
     <dependency>
       <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
       <artifactId>mule-json-module</artifactId>
       <version>2.1.5</version>
       <classifier>mule-plugin</classifier>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/mel/dw_function/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/mel/dw_function/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/munit/munitMockMvn/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/munit/munitMockMvn/output/pom.xml
@@ -23,6 +23,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>com.mulesoft.munit</groupId>
       <artifactId>munit-runner</artifactId>
       <version>2.3.8</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/munit/munitSimple/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/munit/munitSimple/output/pom.xml
@@ -18,6 +18,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>com.mulesoft.munit</groupId>
       <artifactId>munit-runner</artifactId>
       <version>2.3.8</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/munit/munitSimpleMvn/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/munit/munitSimpleMvn/output/pom.xml
@@ -23,6 +23,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>com.mulesoft.munit</groupId>
       <artifactId>munit-runner</artifactId>
       <version>2.3.8</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/oauth2/tweetbook-oauth2-provider/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/oauth2/tweetbook-oauth2-provider/output/pom.xml
@@ -16,6 +16,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/object_store/object_store_01/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/object_store/object_store_01/output/pom.xml
@@ -22,6 +22,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-objectstore-connector</artifactId>
       <version>1.2.1</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/object_store/object_store_02/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/object_store/object_store_02/output/pom.xml
@@ -22,6 +22,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-objectstore-connector</artifactId>
       <version>1.2.1</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/object_store/object_store_03/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/object_store/object_store_03/output/pom.xml
@@ -22,6 +22,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-objectstore-connector</artifactId>
       <version>1.2.1</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/policy/client_id_enforcement_policy/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/policy/client_id_enforcement_policy/output/pom.xml
@@ -25,6 +25,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>com.mulesoft.anypoint</groupId>
       <artifactId>mule-client-id-enforcement-extension</artifactId>
       <version>1.1.4</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/policy/policy_simple/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/policy/policy_simple/output/pom.xml
@@ -25,6 +25,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>com.mulesoft.anypoint</groupId>
       <artifactId>mule-http-policy-transform-extension</artifactId>
       <version>3.0.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/poll/poll1Mvn/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/poll/poll1Mvn/output/pom.xml
@@ -21,6 +21,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/poll/poll1Watermark/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/poll/poll1Watermark/output/pom.xml
@@ -27,6 +27,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/poll/poll2Watermark/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/poll/poll2Watermark/output/pom.xml
@@ -27,6 +27,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/properties/properties01/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/properties/properties01/output/pom.xml
@@ -14,6 +14,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/properties/properties02/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/properties/properties02/output/pom.xml
@@ -14,6 +14,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/proxy/agw_domain/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/proxy/agw_domain/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/proxy/http/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/proxy/http/output/pom.xml
@@ -21,6 +21,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/proxy/raml/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/proxy/raml/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/proxy/using_domain/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/proxy/using_domain/output/pom.xml
@@ -21,6 +21,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/scatter_gather/scatter_gather_01/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/scatter_gather/scatter_gather_01/output/pom.xml
@@ -14,6 +14,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/scatter_gather/scatter_gather_02/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/scatter_gather/scatter_gather_02/output/pom.xml
@@ -14,6 +14,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/sftp/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/sftp/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-sftp-connector</artifactId>
       <version>1.4.1</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/soapkit/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/soapkit/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-http-connector</artifactId>
       <version>1.6.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/splitter-aggregator/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/splitter-aggregator/output/pom.xml
@@ -23,6 +23,12 @@
     </dependency>
     <dependency>
       <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
       <artifactId>mule-aggregators-module</artifactId>
       <version>1.0.5</version>
       <classifier>mule-plugin</classifier>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/spring/spring_beans/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/spring/spring_beans/output/pom.xml
@@ -16,6 +16,12 @@
     </dependency>
     <dependency>
       <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
       <artifactId>mule-spring-module</artifactId>
       <version>1.3.6</version>
       <classifier>mule-plugin</classifier>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/spring/spring_import1/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/spring/spring_import1/output/pom.xml
@@ -18,6 +18,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>com.mulesoft.munit</groupId>
       <artifactId>munit-runner</artifactId>
       <version>2.3.8</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/until_successful/until_successful_01/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/until_successful/until_successful_01/output/pom.xml
@@ -14,6 +14,12 @@
       <version>1.4.0</version>
       <classifier>mule-plugin</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/until_successful/until_successful_02/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/until_successful/until_successful_02/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-vm-connector</artifactId>
       <version>2.0.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/validation/validation1/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/validation/validation1/output/pom.xml
@@ -16,6 +16,12 @@
     </dependency>
     <dependency>
       <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
       <artifactId>mule-validation-module</artifactId>
       <version>1.4.5</version>
       <classifier>mule-plugin</classifier>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/validation/validation2/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/validation/validation2/output/pom.xml
@@ -23,6 +23,12 @@
     </dependency>
     <dependency>
       <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
       <artifactId>mule-validation-module</artifactId>
       <version>1.4.5</version>
       <classifier>mule-plugin</classifier>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/validation/validation3/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/validation/validation3/output/pom.xml
@@ -16,6 +16,12 @@
     </dependency>
     <dependency>
       <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.mule.modules</groupId>
       <artifactId>mule-validation-module</artifactId>
       <version>1.4.5</version>
       <classifier>mule-plugin</classifier>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/vm/vm1/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/vm/vm1/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-vm-connector</artifactId>
       <version>2.0.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/vm/vm2/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/vm/vm2/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-vm-connector</artifactId>
       <version>2.0.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/vm/vm3/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/vm/vm3/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-vm-connector</artifactId>
       <version>2.0.0</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/ws_consumer/wsc1/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/ws_consumer/wsc1/output/pom.xml
@@ -15,6 +15,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-wsc-connector</artifactId>
       <version>1.6.9</version>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/ws_consumer/wsc1Mvn/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/ws_consumer/wsc1Mvn/output/pom.xml
@@ -22,6 +22,12 @@
       <classifier>mule-plugin</classifier>
     </dependency>
     <dependency>
+      <groupId>org.mule.modules</groupId>
+      <artifactId>mule-scripting-module</artifactId>
+      <version>2.0.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
       <groupId>org.mule.connectors</groupId>
       <artifactId>mule-wsc-connector</artifactId>
       <version>1.6.9</version>

--- a/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/steps/core/CompatibilityPomContribution.java
+++ b/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/steps/core/CompatibilityPomContribution.java
@@ -7,6 +7,7 @@ package com.mulesoft.tools.migration.library.mule.steps.core;
 
 import static com.mulesoft.tools.migration.library.tools.PluginsVersions.targetVersion;
 
+import com.mulesoft.tools.migration.library.mule.steps.scripting.ScriptingPomContribution;
 import com.mulesoft.tools.migration.project.model.pom.Dependency.DependencyBuilder;
 import com.mulesoft.tools.migration.project.model.pom.PomModel;
 import com.mulesoft.tools.migration.step.category.MigrationReport;
@@ -19,6 +20,8 @@ import com.mulesoft.tools.migration.step.category.PomContribution;
  * @since 1.0.0
  */
 public class CompatibilityPomContribution implements PomContribution {
+
+  private ScriptingPomContribution scriptingPomContribution = new ScriptingPomContribution();
 
   @Override
   public String getDescription() {
@@ -33,6 +36,9 @@ public class CompatibilityPomContribution implements PomContribution {
         .withVersion(targetVersion("mule-compatibility-module"))
         .withClassifier("mule-plugin")
         .build());
+
+    // compatibility depends on scripting
+    scriptingPomContribution.execute(object, report);
   }
 
 }


### PR DESCRIPTION
Compatibility depends on Scripting but the dependency is missing in compatibility's pom.xml so it needs to be added to the migrated application pom whenever compatibility is used