### PR TITLE
Fallback strategy when properties are not found in the context

### DIFF
--- a/mule-migration-tool-api/src/main/java/com/mulesoft/tools/migration/project/model/ApplicationModel.java
+++ b/mule-migration-tool-api/src/main/java/com/mulesoft/tools/migration/project/model/ApplicationModel.java
@@ -52,8 +52,6 @@ import org.jdom2.output.XMLOutputter;
 import org.jdom2.xpath.XPathExpression;
 import org.jdom2.xpath.XPathFactory;
 
-import javax.print.Doc;
-
 /**
  * Represent the application to be migrated
  *
@@ -457,6 +455,13 @@ public class ApplicationModel {
     return this.applicationGraph;
   }
 
+  /**
+   * @return true if running in NO Compatibility mode.
+   */
+  public boolean noCompatibilityMode() {
+    return this.applicationGraph != null;
+  }
+
   public void addApplicationDocument(Path path, Document document) {
     this.applicationDocuments.put(path, document);
   }
@@ -630,7 +635,7 @@ public class ApplicationModel {
     /**
      * Generate element synthetic ids
      *
-     * @param generateElementIds generate ids or ot
+     * @param generateElementIds generate ids or not
      * @return the builder
      */
     public ApplicationModelBuilder withGenerateElementIds(boolean generateElementIds) {

--- a/mule-migration-tool-api/src/main/java/com/mulesoft/tools/migration/step/util/XmlDslUtils.java
+++ b/mule-migration-tool-api/src/main/java/com/mulesoft/tools/migration/step/util/XmlDslUtils.java
@@ -137,7 +137,7 @@ public final class XmlDslUtils {
     addCompatibilityNamespace(element.getDocument());
 
     int index = element.getParent().indexOf(element);
-    if (appModel.getApplicationGraph() == null) {
+    if (!appModel.noCompatibilityMode()) {
       buildAttributesToInboundProperties(report, element.getParent(), index + 1);
       if (expectsOutboundProperties) {
         Element errorHandlerElement = getFlowExceptionHandlingElement(element.getParentElement());
@@ -204,7 +204,7 @@ public final class XmlDslUtils {
 
     int index = element.getParent().indexOf(element);
 
-    if (appModel.getApplicationGraph() == null) {
+    if (!appModel.noCompatibilityMode()) {
       if (!"true".equals(element.getAttributeValue("isPolledConsumer", MIGRATION_NAMESPACE))) {
         buildOutboundPropertiesToVar(report, element.getParent(), index, consumeStreams);
       }

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/integration/flowref_choice/input/src/main/app/mule-config.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/integration/flowref_choice/input/src/main/app/mule-config.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+      xmlns:file="http://www.mulesoft.org/schema/mule/file"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:sftp="http://www.mulesoft.org/schema/mule/sftp"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+      http://www.mulesoft.org/schema/mule/file http://www.mulesoft.org/schema/mule/file/current/mule-file.xsd
+      http://www.mulesoft.org/schema/mule/sftp http://www.mulesoft.org/schema/mule/sftp/current/mule-sftp.xsd
+      http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <file:connector name="File" outputPattern="test123.txt" autoDelete="true" streaming="true" validateConnections="true" />
+
+    <flow name="file-level1">
+        <file:inbound-endpoint path="someDir/subdir" connector-ref="File" responseTimeout="10000" moveToDirectory="someDir/subdir/output" />
+        <set-property propertyName="at-file-level1" value="doh" />
+        <set-property propertyName="common-level1" value="doh" />
+        <flow-ref name="subflow" />
+
+        <logger message="#[message.outboundProperties['at-sftp-level1']]" /><!-- never -->
+        <logger message="#[message.outboundProperties['at-file-level1']]" /><!-- always -->
+        <logger message="#[message.outboundProperties['common-level1']]" /><!-- always -->
+        <logger message="#[message.outboundProperties['at-sub-flow-level2']]" /><!-- always -->
+
+        <logger message="#[message.inboundProperties['filename']]" /><!-- both file and sftp: translate to different attributes -->
+        <logger message="#[message.inboundProperties['fileSize']]" /><!-- only file -->
+    </flow>
+
+    <flow name="sftp-level1">
+        <sftp:inbound-endpoint name="inboundEndpoint" address="sftp://${USER1_NAME}:${USER1_PASSWORD}@${SFTP_HOST}:${SFTP_PORT}/~/data" />
+        <set-property propertyName="at-sftp-level1" value="doh" />
+        <set-property propertyName="common-level1" value="doh" />
+        <choice>
+            <when expression="#[payload.length() > 0]">
+                <flow-ref name="subflow" />
+            </when>
+            <otherwise>
+                <set-property propertyName="otherwise" value="doh" />
+            </otherwise>
+        </choice>
+
+        <logger message="#[message.outboundProperties['at-sftp-level1']]" /><!-- always -->
+        <logger message="#[message.outboundProperties['at-file-level1']]" /><!-- never -->
+        <logger message="#[message.outboundProperties['common-level1']]" /><!-- always -->
+        <logger message="#[message.outboundProperties['otherwise']]" /><!-- sometimes -->
+        <logger message="#[message.outboundProperties['at-sub-flow-level2']]" /><!-- sometimes -->
+
+        <logger message="#[message.inboundProperties['filename']]" /><!-- both file and sftp: translate to different attributes -->
+        <logger message="#[message.inboundProperties['fileSize']]" /><!-- only file -->
+    </flow>
+
+    <sub-flow name="subflow">
+        <set-property propertyName="at-sub-flow-level2" value="doh" />
+
+        <logger message="#[message.outboundProperties['at-sftp-level1']]" /><!-- sometimes -->
+        <logger message="#[message.outboundProperties['at-file-level1']]" /><!-- sometimes -->
+        <logger message="#[message.outboundProperties['common-level1']]" /><!-- always -->
+        <logger message="#[message.outboundProperties['at-sub-flow-level2']]" /><!-- always -->
+
+        <logger message="#[message.inboundProperties['filename']]" /><!-- both file and sftp: translate to different attributes -->
+        <logger message="#[message.inboundProperties['fileSize']]" /><!-- only file -->
+    </sub-flow>
+
+</mule>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/integration/flowref_choice/output/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/integration/flowref_choice/output/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.mule.migrated</groupId>
+  <artifactId>flowref_choice</artifactId>
+  <version>1.0.0-M4-SNAPSHOT</version>
+  <packaging>mule-application</packaging>
+  <description>Application migrated with MMA</description>
+  <dependencies>
+    <dependency>
+      <groupId>com.mulesoft.mule.modules</groupId>
+      <artifactId>mule-compatibility-module</artifactId>
+      <version>1.4.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.mule.connectors</groupId>
+      <artifactId>mule-file-connector</artifactId>
+      <version>1.3.4</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.mule.connectors</groupId>
+      <artifactId>mule-sftp-connector</artifactId>
+      <version>1.4.1</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+  </dependencies>
+  <repositories>
+    <repository>
+      <id>mulesoft-releases</id>
+      <name>MuleSoft Releases Repository</name>
+      <url>https://repository.mulesoft.org/releases/</url>
+    </repository>
+    <repository>
+      <id>anypoint-exchange</id>
+      <name>Anypoint Exchange</name>
+      <url>https://maven.anypoint.mulesoft.com/api/v1/maven</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>mulesoft-releases</id>
+      <name>MuleSoft Releases Repository</name>
+      <url>https://repository.mulesoft.org/releases/</url>
+    </pluginRepository>
+  </pluginRepositories>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.mule.tools.maven</groupId>
+        <artifactId>mule-maven-plugin</artifactId>
+        <version>3.2.1</version>
+        <extensions>true</extensions>
+        <configuration />
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/integration/flowref_choice/output/report/report.json
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/integration/flowref_choice/output/report/report.json
@@ -1,0 +1,168 @@
+{
+  "projectType": "MULE_THREE_APPLICATION",
+  "projectName": "input",
+  "connectorsMigrated": [
+    "org.mule.connectors:mule-file-connector:1.3.4",
+    "org.mule.connectors:mule-sftp-connector:1.4.1"
+  ],
+  "numberOfMuleComponents": 34,
+  "numberOfMuleComponentsMigrated": 34,
+  "componentDetails": {
+    "mule": {
+      "success": 1,
+      "failure": 0
+    },
+    "logger": {
+      "success": 19,
+      "failure": 0
+    },
+    "flow": {
+      "success": 2,
+      "failure": 0
+    },
+    "flow-ref": {
+      "success": 2,
+      "failure": 0
+    },
+    "choice": {
+      "success": 1,
+      "failure": 0
+    },
+    "file:config": {
+      "success": 1,
+      "failure": 0
+    },
+    "file:listener": {
+      "success": 1,
+      "failure": 0
+    },
+    "sftp:listener": {
+      "success": 1,
+      "failure": 0
+    },
+    "compatibility:set-property": {
+      "success": 6,
+      "failure": 0
+    }
+  },
+  "numberOfMELExpressions": 20,
+  "numberOfMELExpressionsMigrated": 20,
+  "numberOfMELExpressionLines": 20,
+  "numberOfMELExpressionLinesMigrated": 20,
+  "numberOfDWTransformations": 0,
+  "numberOfDWTransformationsMigrated": 0,
+  "numberOfDWTransformationLines": 0,
+  "numberOfDWTransformationLinesMigrated": 0,
+  "detailedMessages": [
+    {
+      "level": "WARN",
+      "key": "message.attributesToInboundProperties",
+      "component": "compatibility:attributes-to-inbound-properties",
+      "lineNumber": 0,
+      "columnNumber": 0,
+      "message": "Expressions that query \u0027inboundProperties\u0027 from the message should instead query the message \u0027attributes\u0027. Remove this component if there are no uses of \u0027inboundProperties\u0027 in expressions or components that rely on \u0027inboundProperties\u0027 (such as \u0027copy-properties\u0027).",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    },
+    {
+      "level": "WARN",
+      "key": "message.outboundProperties",
+      "component": "compatibility:outbound-properties-to-var",
+      "lineNumber": 0,
+      "columnNumber": 0,
+      "message": "Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as \u0027method\u0027) of the operation or listener that accepts the expression.",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    },
+    {
+      "level": "INFO",
+      "key": "file.responseTimeout",
+      "component": "file:listener",
+      "lineNumber": 11,
+      "columnNumber": 120,
+      "message": "\u0027responseTimeout\u0027 was not being used by the file transport.",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    },
+    {
+      "level": "WARN",
+      "key": "message.outboundProperties",
+      "component": "compatibility:set-property",
+      "lineNumber": 31,
+      "columnNumber": 79,
+      "message": "Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as \u0027method\u0027) of the operation or listener that accepts the expression.",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    },
+    {
+      "level": "WARN",
+      "key": "message.outboundProperties",
+      "component": "compatibility:set-property",
+      "lineNumber": 37,
+      "columnNumber": 78,
+      "message": "Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as \u0027method\u0027) of the operation or listener that accepts the expression.",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    },
+    {
+      "level": "WARN",
+      "key": "message.attributesToInboundProperties",
+      "component": "compatibility:attributes-to-inbound-properties",
+      "lineNumber": 78,
+      "columnNumber": 57,
+      "message": "Expressions that query \u0027inboundProperties\u0027 from the message should instead query the message \u0027attributes\u0027. Remove this component if there are no uses of \u0027inboundProperties\u0027 in expressions or components that rely on \u0027inboundProperties\u0027 (such as \u0027copy-properties\u0027).",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    },
+    {
+      "level": "WARN",
+      "key": "message.outboundProperties",
+      "component": "compatibility:set-property",
+      "lineNumber": 85,
+      "columnNumber": 79,
+      "message": "Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as \u0027method\u0027) of the operation or listener that accepts the expression.",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    },
+    {
+      "level": "WARN",
+      "key": "message.outboundProperties",
+      "component": "compatibility:set-property",
+      "lineNumber": 91,
+      "columnNumber": 78,
+      "message": "Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as \u0027method\u0027) of the operation or listener that accepts the expression.",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    },
+    {
+      "level": "WARN",
+      "key": "message.outboundProperties",
+      "component": "compatibility:set-property",
+      "lineNumber": 102,
+      "columnNumber": 82,
+      "message": "Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as \u0027method\u0027) of the operation or listener that accepts the expression.",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    },
+    {
+      "level": "WARN",
+      "key": "message.outboundProperties",
+      "component": "compatibility:outbound-properties-to-var",
+      "lineNumber": 131,
+      "columnNumber": 51,
+      "message": "Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as \u0027method\u0027) of the operation or listener that accepts the expression.",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    },
+    {
+      "level": "WARN",
+      "key": "message.outboundProperties",
+      "component": "compatibility:set-property",
+      "lineNumber": 140,
+      "columnNumber": 83,
+      "message": "Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as \u0027method\u0027) of the operation or listener that accepts the expression.",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    }
+  ]
+}

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/integration/flowref_choice/output/src/main/mule/mule-config.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/integration/flowref_choice/output/src/main/mule/mule-config.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:compatibility="http://www.mulesoft.org/schema/mule/compatibility" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:file="http://www.mulesoft.org/schema/mule/file" xmlns:sftp="http://www.mulesoft.org/schema/mule/sftp" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/sftp http://www.mulesoft.org/schema/mule/sftp/current/mule-sftp.xsd http://www.mulesoft.org/schema/mule/file http://www.mulesoft.org/schema/mule/file/current/mule-file.xsd http://www.mulesoft.org/schema/mule/compatibility http://www.mulesoft.org/schema/mule/compatibility/current/mule-compatibility.xsd http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <file:config name="File">
+        <file:connection workingDir=".">
+            <reconnection failsDeployment="true" />
+        </file:connection>
+    </file:config>
+
+    <sftp:config name="inboundEndpointConfig">
+        <sftp:connection host="${SFTP_HOST}" port="${SFTP_PORT}" username="${USER1_NAME}" password="${USER1_PASSWORD}">
+            <reconnection failsDeployment="true" />
+        </sftp:connection>
+    </sftp:config>
+
+    <flow name="file-level1">
+        <file:listener directory="someDir/subdir" config-ref="File" moveToDirectory="someDir/subdir/output" recursive="false" applyPostActionWhenFailed="false">
+            <!--Migration INFO: 'responseTimeout' was not being used by the file transport.-->
+            <scheduling-strategy>
+                <fixed-frequency frequency="1000" />
+            </scheduling-strategy>
+        </file:listener>
+
+        <compatibility:attributes-to-inbound-properties>
+            <!--Migration WARN: Expressions that query 'inboundProperties' from the message should instead query the message 'attributes'. Remove this component if there are no uses of 'inboundProperties' in expressions or components that rely on 'inboundProperties' (such as 'copy-properties').-->
+            <!--    For more information refer to:-->
+            <!--        * https://docs.mulesoft.com/mule-runtime/4.3/intro-mule-message#inbound-properties-are-now-attributes-->
+            <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool-post-mig.adoc#inbound_properties-->
+        </compatibility:attributes-to-inbound-properties>
+
+        <compatibility:set-property propertyName="at-file-level1" value="doh">
+            <!--Migration WARN: Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as 'method') of the operation or listener that accepts the expression.-->
+            <!--    For more information refer to:-->
+            <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool-post-mig.adoc#outbound_properties-->
+        </compatibility:set-property>
+
+        <compatibility:set-property propertyName="common-level1" value="doh">
+            <!--Migration WARN: Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as 'method') of the operation or listener that accepts the expression.-->
+            <!--    For more information refer to:-->
+            <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool-post-mig.adoc#outbound_properties-->
+        </compatibility:set-property>
+
+        <flow-ref name="subflow" />
+
+        <logger message="#[vars.compatibility_outboundProperties['at-sftp-level1']]" />
+
+        <!-- never -->
+        <logger message="#[vars.compatibility_outboundProperties['at-file-level1']]" />
+
+        <!-- always -->
+        <logger message="#[vars.compatibility_outboundProperties['common-level1']]" />
+
+        <!-- always -->
+        <logger message="#[vars.compatibility_outboundProperties['at-sub-flow-level2']]" />
+
+        <!-- always -->
+        <logger message="#[vars.compatibility_inboundProperties['filename']]" />
+
+        <!-- both file and sftp: translate to different attributes -->
+        <logger message="#[vars.compatibility_inboundProperties['fileSize']]" />
+
+        <!-- only file -->
+        <compatibility:outbound-properties-to-var>
+            <!--Migration WARN: Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as 'method') of the operation or listener that accepts the expression.-->
+            <!--    For more information refer to:-->
+            <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool-post-mig.adoc#outbound_properties-->
+        </compatibility:outbound-properties-to-var>
+
+    </flow>
+
+    <flow name="sftp-level1">
+        <sftp:listener directory="data" config-ref="inboundEndpointConfig">
+            <scheduling-strategy>
+                <fixed-frequency frequency="1000" />
+            </scheduling-strategy>
+        </sftp:listener>
+
+        <compatibility:attributes-to-inbound-properties>
+            <!--Migration WARN: Expressions that query 'inboundProperties' from the message should instead query the message 'attributes'. Remove this component if there are no uses of 'inboundProperties' in expressions or components that rely on 'inboundProperties' (such as 'copy-properties').-->
+            <!--    For more information refer to:-->
+            <!--        * https://docs.mulesoft.com/mule-runtime/4.3/intro-mule-message#inbound-properties-are-now-attributes-->
+            <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool-post-mig.adoc#inbound_properties-->
+        </compatibility:attributes-to-inbound-properties>
+
+        <compatibility:set-property propertyName="at-sftp-level1" value="doh">
+            <!--Migration WARN: Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as 'method') of the operation or listener that accepts the expression.-->
+            <!--    For more information refer to:-->
+            <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool-post-mig.adoc#outbound_properties-->
+        </compatibility:set-property>
+
+        <compatibility:set-property propertyName="common-level1" value="doh">
+            <!--Migration WARN: Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as 'method') of the operation or listener that accepts the expression.-->
+            <!--    For more information refer to:-->
+            <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool-post-mig.adoc#outbound_properties-->
+        </compatibility:set-property>
+
+        <choice>
+            <when expression="#[length(payload) &gt; 0]">
+                <flow-ref name="subflow" />
+            </when>
+            <otherwise>
+                <compatibility:set-property propertyName="otherwise" value="doh">
+                    <!--Migration WARN: Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as 'method') of the operation or listener that accepts the expression.-->
+                    <!--    For more information refer to:-->
+                    <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool-post-mig.adoc#outbound_properties-->
+                </compatibility:set-property>
+            </otherwise>
+        </choice>
+
+        <logger message="#[vars.compatibility_outboundProperties['at-sftp-level1']]" />
+
+        <!-- always -->
+        <logger message="#[vars.compatibility_outboundProperties['at-file-level1']]" />
+
+        <!-- never -->
+        <logger message="#[vars.compatibility_outboundProperties['common-level1']]" />
+
+        <!-- always -->
+        <logger message="#[vars.compatibility_outboundProperties['otherwise']]" />
+
+        <!-- sometimes -->
+        <logger message="#[vars.compatibility_outboundProperties['at-sub-flow-level2']]" />
+
+        <!-- sometimes -->
+        <logger message="#[vars.compatibility_inboundProperties['filename']]" />
+
+        <!-- both file and sftp: translate to different attributes -->
+        <logger message="#[vars.compatibility_inboundProperties['fileSize']]" />
+
+        <!-- only file -->
+        <compatibility:outbound-properties-to-var>
+            <!--Migration WARN: Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as 'method') of the operation or listener that accepts the expression.-->
+            <!--    For more information refer to:-->
+            <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool-post-mig.adoc#outbound_properties-->
+        </compatibility:outbound-properties-to-var>
+
+    </flow>
+
+    <sub-flow name="subflow">
+        <compatibility:set-property propertyName="at-sub-flow-level2" value="doh">
+            <!--Migration WARN: Instead of using outbound properties in the flow, move the expression that sets the property into the XML attribute (such as 'method') of the operation or listener that accepts the expression.-->
+            <!--    For more information refer to:-->
+            <!--        * https://github.com/mulesoft/mule-migration-assistant/blob/master/docs/user-docs/migration-tool-post-mig.adoc#outbound_properties-->
+        </compatibility:set-property>
+        <logger message="#[vars.compatibility_outboundProperties['at-sftp-level1']]" />
+        <!-- sometimes -->
+        <logger message="#[vars.compatibility_outboundProperties['at-file-level1']]" />
+        <!-- sometimes -->
+        <logger message="#[vars.compatibility_outboundProperties['common-level1']]" />
+        <!-- always -->
+        <logger message="#[vars.compatibility_outboundProperties['at-sub-flow-level2']]" />
+        <!-- always -->
+        <logger message="#[vars.compatibility_inboundProperties['filename']]" />
+        <!-- both file and sftp: translate to different attributes -->
+        <logger message="#[vars.compatibility_inboundProperties['fileSize']]" />
+        <!-- only file -->
+    </sub-flow>
+
+</mule>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/integration/flowref_choice/output_nc/pom.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/integration/flowref_choice/output_nc/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.mule.migrated</groupId>
+  <artifactId>flowref_choice</artifactId>
+  <version>1.0.0-M4-SNAPSHOT</version>
+  <packaging>mule-application</packaging>
+  <description>Application migrated with MMA</description>
+  <dependencies>
+    <dependency>
+      <groupId>com.mulesoft.mule.modules</groupId>
+      <artifactId>mule-compatibility-module</artifactId>
+      <version>1.4.0</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.mule.connectors</groupId>
+      <artifactId>mule-file-connector</artifactId>
+      <version>1.3.4</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.mule.connectors</groupId>
+      <artifactId>mule-sftp-connector</artifactId>
+      <version>1.4.1</version>
+      <classifier>mule-plugin</classifier>
+    </dependency>
+  </dependencies>
+  <repositories>
+    <repository>
+      <id>mulesoft-releases</id>
+      <name>MuleSoft Releases Repository</name>
+      <url>https://repository.mulesoft.org/releases/</url>
+    </repository>
+    <repository>
+      <id>anypoint-exchange</id>
+      <name>Anypoint Exchange</name>
+      <url>https://maven.anypoint.mulesoft.com/api/v1/maven</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>mulesoft-releases</id>
+      <name>MuleSoft Releases Repository</name>
+      <url>https://repository.mulesoft.org/releases/</url>
+    </pluginRepository>
+  </pluginRepositories>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.mule.tools.maven</groupId>
+        <artifactId>mule-maven-plugin</artifactId>
+        <version>3.2.1</version>
+        <extensions>true</extensions>
+        <configuration />
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/integration/flowref_choice/output_nc/report/report.json
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/integration/flowref_choice/output_nc/report/report.json
@@ -1,0 +1,88 @@
+{
+  "projectType": "MULE_THREE_APPLICATION",
+  "projectName": "input",
+  "connectorsMigrated": [
+    "org.mule.connectors:mule-file-connector:1.3.4",
+    "org.mule.connectors:mule-sftp-connector:1.4.1"
+  ],
+  "numberOfMuleComponents": 34,
+  "numberOfMuleComponentsMigrated": 34,
+  "componentDetails": {
+    "mule": {
+      "success": 1,
+      "failure": 0
+    },
+    "logger": {
+      "success": 19,
+      "failure": 0
+    },
+    "flow": {
+      "success": 2,
+      "failure": 0
+    },
+    "flow-ref": {
+      "success": 2,
+      "failure": 0
+    },
+    "choice": {
+      "success": 1,
+      "failure": 0
+    },
+    "file:config": {
+      "success": 1,
+      "failure": 0
+    },
+    "file:listener": {
+      "success": 1,
+      "failure": 0
+    },
+    "sftp:listener": {
+      "success": 1,
+      "failure": 0
+    },
+    "set-variable": {
+      "success": 6,
+      "failure": 0
+    }
+  },
+  "numberOfMELExpressions": 20,
+  "numberOfMELExpressionsMigrated": 20,
+  "numberOfMELExpressionLines": 20,
+  "numberOfMELExpressionLinesMigrated": 20,
+  "numberOfDWTransformations": 0,
+  "numberOfDWTransformationsMigrated": 0,
+  "numberOfDWTransformationLines": 0,
+  "numberOfDWTransformationLinesMigrated": 0,
+  "detailedMessages": [
+    {
+      "level": "INFO",
+      "key": "file.responseTimeout",
+      "component": "file:listener",
+      "lineNumber": 11,
+      "columnNumber": 120,
+      "message": "\u0027responseTimeout\u0027 was not being used by the file transport.",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    },
+    {
+      "level": "WARN",
+      "key": "nocompatibility.notfullyimplemented",
+      "component": "file:listener",
+      "lineNumber": 11,
+      "columnNumber": 120,
+      "message": "No compatibility mode is not fully implemented so connectors might experience issues with missing inbound/outbound property migrations.",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    },
+    {
+      "level": "WARN",
+      "key": "nocompatibility.notfullyimplemented",
+      "component": "sftp:listener",
+      "lineNumber": 52,
+      "columnNumber": 76,
+      "message": "No compatibility mode is not fully implemented so connectors might experience issues with missing inbound/outbound property migrations.",
+      "filePath": "src/main/mule/mule-config.xml",
+      "documentationLinks": []
+    }
+  ]
+}

--- a/mule-migration-tool-e2e-tests/src/test/resources/e2e/integration/flowref_choice/output_nc/src/main/mule/mule-config.xml
+++ b/mule-migration-tool-e2e-tests/src/test/resources/e2e/integration/flowref_choice/output_nc/src/main/mule/mule-config.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:file="http://www.mulesoft.org/schema/mule/file" xmlns:sftp="http://www.mulesoft.org/schema/mule/sftp" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/sftp http://www.mulesoft.org/schema/mule/sftp/current/mule-sftp.xsd http://www.mulesoft.org/schema/mule/file http://www.mulesoft.org/schema/mule/file/current/mule-file.xsd http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <file:config name="File">
+        <file:connection workingDir=".">
+            <reconnection failsDeployment="true" />
+        </file:connection>
+    </file:config>
+
+    <sftp:config name="inboundEndpointConfig">
+        <sftp:connection host="${SFTP_HOST}" port="${SFTP_PORT}" username="${USER1_NAME}" password="${USER1_PASSWORD}">
+            <reconnection failsDeployment="true" />
+        </sftp:connection>
+    </sftp:config>
+
+    <flow name="file-level1">
+        <file:listener directory="someDir/subdir" config-ref="File" moveToDirectory="someDir/subdir/output" recursive="false" applyPostActionWhenFailed="false">
+            <!--Migration INFO: 'responseTimeout' was not being used by the file transport.-->
+            <!--Migration WARN: No compatibility mode is not fully implemented so connectors might experience issues with missing inbound/outbound property migrations.-->
+            <scheduling-strategy>
+                <fixed-frequency frequency="1000" />
+            </scheduling-strategy>
+        </file:listener>
+
+        <set-variable variableName="outbound_at-file-level1" value="doh" />
+
+        <set-variable variableName="outbound_common-level1" value="doh" />
+
+        <flow-ref name="subflow" />
+
+        <logger message="#[vars.outbound_at-sftp-level1]" />
+
+        <!-- never -->
+        <logger message="#[vars.outbound_at-file-level1]" />
+
+        <!-- always -->
+        <logger message="#[vars.outbound_common-level1]" />
+
+        <!-- always -->
+        <logger message="#[vars.outbound_at-sub-flow-level2]" />
+
+        <!-- always -->
+        <logger message="#[message.attributes.fileName]" />
+
+        <!-- both file and sftp: translate to different attributes -->
+        <logger message="#[message.attributes.size]" />
+
+        <!-- only file -->
+    </flow>
+
+    <flow name="sftp-level1">
+        <sftp:listener directory="data" config-ref="inboundEndpointConfig">
+            <!--Migration WARN: No compatibility mode is not fully implemented so connectors might experience issues with missing inbound/outbound property migrations.-->
+            <scheduling-strategy>
+                <fixed-frequency frequency="1000" />
+            </scheduling-strategy>
+        </sftp:listener>
+
+        <set-variable variableName="outbound_at-sftp-level1" value="doh" />
+
+        <set-variable variableName="outbound_common-level1" value="doh" />
+
+        <choice>
+            <when expression="#[length(payload) &gt; 0]">
+                <flow-ref name="subflow" />
+            </when>
+            <otherwise>
+                <set-variable variableName="outbound_otherwise" value="doh" />
+            </otherwise>
+        </choice>
+
+        <logger message="#[vars.outbound_at-sftp-level1]" />
+
+        <!-- always -->
+        <logger message="#[vars.outbound_at-file-level1]" />
+
+        <!-- never -->
+        <logger message="#[vars.outbound_common-level1]" />
+
+        <!-- always -->
+        <logger message="#[vars.outbound_otherwise]" />
+
+        <!-- sometimes -->
+        <logger message="#[vars.outbound_at-sub-flow-level2]" />
+
+        <!-- sometimes -->
+        <logger message="#[message.attributes.name]" />
+
+        <!-- both file and sftp: translate to different attributes -->
+        <logger message="#[message.attributes.size]" />
+
+        <!-- only file -->
+    </flow>
+
+    <sub-flow name="subflow">
+        <set-variable variableName="outbound_at-sub-flow-level2" value="doh" />
+        <logger message="#[vars.outbound_at-sftp-level1]" />
+        <!-- sometimes -->
+        <logger message="#[vars.outbound_at-file-level1]" />
+        <!-- sometimes -->
+        <logger message="#[vars.outbound_common-level1]" />
+        <!-- always -->
+        <logger message="#[vars.outbound_at-sub-flow-level2]" />
+        <!-- always -->
+        <logger message="#[message.attributes.fileName]" />
+        <!-- both file and sftp: translate to different attributes -->
+        <logger message="#[message.attributes.size]" />
+        <!-- only file -->
+    </sub-flow>
+
+</mule>

--- a/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/steps/core/RemoveProperty.java
+++ b/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/steps/core/RemoveProperty.java
@@ -11,10 +11,8 @@ import static com.mulesoft.tools.migration.project.model.ApplicationModelUtils.c
 import static com.mulesoft.tools.migration.project.model.applicationgraph.SetPropertyProcessor.OUTBOUND_PREFIX;
 import static com.mulesoft.tools.migration.step.util.TransportsUtils.COMPATIBILITY_NAMESPACE;
 import static com.mulesoft.tools.migration.step.util.XmlDslUtils.*;
-import static java.util.Optional.empty;
 import static java.util.Optional.of;
 
-import com.mulesoft.tools.migration.project.model.applicationgraph.RemovePropertyProcessor;
 import com.mulesoft.tools.migration.step.AbstractApplicationModelMigrationStep;
 import com.mulesoft.tools.migration.step.category.MigrationReport;
 
@@ -42,18 +40,11 @@ public class RemoveProperty extends AbstractApplicationModelMigrationStep {
 
   @Override
   public void execute(Element element, MigrationReport report) throws RuntimeException {
-    if (getApplicationModel().getApplicationGraph() != null) {
+    if (getApplicationModel().noCompatibilityMode()) {
       String propertyName = element.getAttributeValue("propertyName");
-      RemovePropertyProcessor processor = (RemovePropertyProcessor) getApplicationModel()
-          .getApplicationGraph().findFlowComponent(element);
-      String variableNameTranslation = processor.getPropertiesMigrationContext().getOutboundContext()
-          .get(propertyName).getTranslation();
-      if (variableNameTranslation != null) {
-        variableNameTranslation = variableNameTranslation.replace("vars.", "");
-        changeNodeName("", "remove-variable")
-            .andThen(changeAttribute("propertyName", of("variableName"), of(variableNameTranslation)))
-            .apply(element);
-      }
+      changeNodeName("", "remove-variable")
+          .andThen(changeAttribute("propertyName", of("variableName"), of(OUTBOUND_PREFIX + propertyName)))
+          .apply(element);
     } else {
       addCompatibilityNamespace(element.getDocument());
       report.report("message.outboundProperties", element, element);

--- a/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/steps/core/SetProperty.java
+++ b/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/steps/core/SetProperty.java
@@ -12,11 +12,8 @@ import static com.mulesoft.tools.migration.project.model.applicationgraph.SetPro
 import static com.mulesoft.tools.migration.step.util.TransportsUtils.COMPATIBILITY_NAMESPACE;
 import static com.mulesoft.tools.migration.step.util.XmlDslUtils.addCompatibilityNamespace;
 import static com.mulesoft.tools.migration.step.util.XmlDslUtils.migrateExpression;
-import static java.util.Optional.empty;
 import static java.util.Optional.of;
 
-import com.mulesoft.tools.migration.project.model.applicationgraph.RemovePropertyProcessor;
-import com.mulesoft.tools.migration.project.model.applicationgraph.SetPropertyProcessor;
 import com.mulesoft.tools.migration.step.AbstractApplicationModelMigrationStep;
 import com.mulesoft.tools.migration.step.ExpressionMigratorAware;
 import com.mulesoft.tools.migration.step.category.MigrationReport;
@@ -48,19 +45,11 @@ public class SetProperty extends AbstractApplicationModelMigrationStep implement
 
   @Override
   public void execute(Element element, MigrationReport report) throws RuntimeException {
-    if (getApplicationModel().getApplicationGraph() != null) {
+    if (getApplicationModel().noCompatibilityMode()) {
       String propertyName = element.getAttributeValue("propertyName");
-
-      SetPropertyProcessor processor = (SetPropertyProcessor) getApplicationModel()
-          .getApplicationGraph().findFlowComponent(element);
-      String variableNameTranslation = processor.getPropertiesMigrationContext().getOutboundContext()
-          .get(propertyName).getTranslation();
-      if (variableNameTranslation != null) {
-        variableNameTranslation = variableNameTranslation.replace("vars.", "");
-        changeNodeName("", "set-variable")
-            .andThen(changeAttribute("propertyName", of("variableName"), of(variableNameTranslation)))
-            .apply(element);
-      }
+      changeNodeName("", SET_VARIABLE)
+          .andThen(changeAttribute("propertyName", of("variableName"), of(OUTBOUND_PREFIX + propertyName)))
+          .apply(element);
       migrateExpression(element.getAttribute("value"), getExpressionMigrator());
     } else {
       migrateExpression(element.getAttribute("value"), getExpressionMigrator());

--- a/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/steps/http/HttpConnectorRequester.java
+++ b/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/mule/steps/http/HttpConnectorRequester.java
@@ -74,7 +74,7 @@ public class HttpConnectorRequester extends AbstractHttpConnectorMigrationStep {
     migrateExpression(object.getAttribute("followRedirects"), getExpressionMigrator());
 
     migrateOperationStructure(getApplicationModel(), object, report, true, getExpressionMigrator(),
-                              new MelCompatibilityResolver(getApplicationModel().getApplicationGraph()));
+                              new MelCompatibilityResolver());
     addAttributesToInboundProperties(object, getApplicationModel(), report);
 
     object.getChildren().forEach(c -> {

--- a/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/nocompatibility/InboundToAttributesTranslator.java
+++ b/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/nocompatibility/InboundToAttributesTranslator.java
@@ -17,8 +17,10 @@ import com.mulesoft.tools.migration.library.mule.steps.sftp.SftpInboundEndpoint;
 import com.mulesoft.tools.migration.library.mule.steps.wsc.WsConsumer;
 import com.mulesoft.tools.migration.project.model.applicationgraph.SourceType;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -56,8 +58,22 @@ public class InboundToAttributesTranslator implements PropertyTranslator {
         .build();
   }
 
+  private Map<String, String> allTranslations;
+
   public static List<SourceType> getSupportedConnectors() {
     return Lists.newArrayList(translatorClasses.keySet());
+  }
+
+  @Override
+  public Map<String, String> getAllTranslationsForAllSourceTypes() throws Exception {
+    if (allTranslations == null) {
+      Map<String, String> result = new HashMap<>();
+      for (SourceType sourceType : translatorClasses.keySet()) {
+        result.putAll(getAllTranslationsFor(sourceType).orElseThrow(NoSuchElementException::new));
+      }
+      allTranslations = result;
+    }
+    return allTranslations;
   }
 
   @Override

--- a/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/nocompatibility/PropertyTranslator.java
+++ b/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/nocompatibility/PropertyTranslator.java
@@ -18,6 +18,8 @@ import java.util.Optional;
  */
 public interface PropertyTranslator {
 
+  Map<String, String> getAllTranslationsForAllSourceTypes() throws Exception;
+
   Optional<Map<String, String>> getAllTranslationsFor(SourceType sourceType) throws Exception;
 
   String translateImplicit(String propertyToTranslate, SourceType originatingSourceType);

--- a/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/tools/mel/MelCompatibilityResolver.java
+++ b/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/tools/mel/MelCompatibilityResolver.java
@@ -26,13 +26,11 @@ import java.util.List;
 public class MelCompatibilityResolver implements CompatibilityResolver<String> {
 
   private List<CompatibilityResolver<String>> resolvers;
-  private ApplicationGraph applicationGraph;
 
-  public MelCompatibilityResolver(ApplicationGraph applicationGraph) {
+  public MelCompatibilityResolver() {
     resolvers = new ArrayList<>();
     resolvers.add(new InboundAttachmentsCompatibilityResolver());
     resolvers.add(new HeaderSyntaxCompatibilityResolver());
-    this.applicationGraph = applicationGraph;
   }
 
   @Override

--- a/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/tools/mel/nocompatibility/InboundPropertiesNoCompatibilityResolver.java
+++ b/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/tools/mel/nocompatibility/InboundPropertiesNoCompatibilityResolver.java
@@ -55,4 +55,9 @@ public class InboundPropertiesNoCompatibilityResolver extends PropertiesNoCompat
     return translator;
   }
 
+  @Override
+  protected String fallbackTranslation(String propertyToTranslate) throws Exception {
+    return translator.getAllTranslationsForAllSourceTypes().get(propertyToTranslate);
+  }
+
 }

--- a/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/tools/mel/nocompatibility/MelNoCompatibilityResolver.java
+++ b/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/tools/mel/nocompatibility/MelNoCompatibilityResolver.java
@@ -27,18 +27,16 @@ import java.util.stream.Collectors;
 public class MelNoCompatibilityResolver implements CompatibilityResolver<NoCompatibilityResolverResult> {
 
   protected List<CompatibilityResolver<NoCompatibilityResolverResult>> resolvers;
-  private ApplicationGraph graph;
 
-  public MelNoCompatibilityResolver(ApplicationGraph graph) {
+  public MelNoCompatibilityResolver() {
     resolvers = new ArrayList<>();
     resolvers.add(new InboundPropertiesNoCompatibilityResolver());
     resolvers.add(new OutboundPropertiesNoCompatibilityResolver());
-    this.graph = graph;
   }
 
   @Override
   public boolean canResolve(String original) {
-    return graph != null;
+    return true;
   }
 
   @Override

--- a/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/tools/mel/nocompatibility/OutboundPropertiesNoCompatibilityResolver.java
+++ b/mule-migration-tool-library/src/main/java/com/mulesoft/tools/migration/library/tools/mel/nocompatibility/OutboundPropertiesNoCompatibilityResolver.java
@@ -5,10 +5,13 @@
  */
 package com.mulesoft.tools.migration.library.tools.mel.nocompatibility;
 
-import com.google.common.collect.ImmutableList;
+import static com.mulesoft.tools.migration.project.model.applicationgraph.SetPropertyProcessor.OUTBOUND_PREFIX;
+
 import com.mulesoft.tools.migration.library.nocompatibility.PropertyTranslator;
 import com.mulesoft.tools.migration.project.model.applicationgraph.PropertiesMigrationContext;
 import com.mulesoft.tools.migration.project.model.applicationgraph.PropertyMigrationContext;
+
+import com.google.common.collect.ImmutableList;
 
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -49,6 +52,11 @@ public class OutboundPropertiesNoCompatibilityResolver extends PropertiesNoCompa
   @Override
   protected PropertyTranslator getTranslator() {
     return null;
+  }
+
+  @Override
+  protected String fallbackTranslation(String propertyToTranslate) {
+    return "vars." + OUTBOUND_PREFIX + propertyToTranslate;
   }
 
 }

--- a/mule-migration-tool-library/src/test/java/com/mulesoft/tools/migration/library/mule/steps/core/SetPropertyTest.java
+++ b/mule-migration-tool-library/src/test/java/com/mulesoft/tools/migration/library/mule/steps/core/SetPropertyTest.java
@@ -79,7 +79,7 @@ public class SetPropertyTest {
     Document doc = getDocument(this.getClass().getClassLoader().getResource(FILE_SAMPLE_PATH.toString()).toURI().getPath());
     node = getElementsFromDocument(doc, setProperty.getAppliedTo().getExpression()).get(0);
     ApplicationGraph mockApplicationGraph = mock(ApplicationGraph.class);
-    when(mockApplicationModel.getApplicationGraph()).thenReturn(mockApplicationGraph);
+    when(mockApplicationModel.noCompatibilityMode()).thenReturn(true);
 
     SetPropertyProcessor flowComponent = new SetPropertyProcessor(node, mock(Flow.class), mockApplicationGraph);
     flowComponent.setPropertiesMigrationContext(new PropertiesMigrationContext(Maps.newHashMap(), ImmutableMap
@@ -94,5 +94,6 @@ public class SetPropertyTest {
     assertThat("The node name didn't changed", node.getName(), is("set-variable"));
     assertThat("The attribute was not renamed", node.getAttribute("variableName"), is(notNullValue()));
     assertThat("The attribute was not translated", node.getAttribute("variableName").getValue(), is("outbound_propertyName"));
+    assertThat("The attribute value is wrong", node.getAttributeValue("value"), is("#[2]"));
   }
 }

--- a/mule-migration-tool-library/src/test/java/com/mulesoft/tools/migration/library/mule/steps/nocompatibility/InboundToAttributesTranslatorTest.java
+++ b/mule-migration-tool-library/src/test/java/com/mulesoft/tools/migration/library/mule/steps/nocompatibility/InboundToAttributesTranslatorTest.java
@@ -13,6 +13,8 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import java.util.Map;
+
 public class InboundToAttributesTranslatorTest {
 
   private InboundToAttributesTranslator translator;
@@ -51,5 +53,11 @@ public class InboundToAttributesTranslatorTest {
     assertEquals("(message.attributes.requestPath[1 + sizeOf(if (endsWith(message.attributes.listenerPath, '/*')) "
         + "message.attributes.listenerPath[0 to -3] default '/' else message.attributes.listenerPath) to -1])",
                  translator.getAllTranslationsFor(PropertiesSourceType.HTTP_LISTENER).get().get("http.relative.path"));
+  }
+
+  @Test
+  public void testGetAllTranslationsForAllSourceTypes() throws Exception {
+    Map<String, String> allTranslationsForAllSourceTypes = translator.getAllTranslationsForAllSourceTypes();
+    assertEquals(47, allTranslationsForAllSourceTypes.size());
   }
 }


### PR DESCRIPTION
Graph only used for Inbound context, if IB property not found in current context check all transports properties.
IB property name collisions are not being handled at the moment, will be tackled as a separate task if needed.
